### PR TITLE
Decode level of ParamDescription

### DIFF
--- a/src/dynamic_reconfigure/encoding.py
+++ b/src/dynamic_reconfigure/encoding.py
@@ -167,6 +167,7 @@ def decode_description(msg):
                'max' : maxes[name],
                'default' : defaults[name],
                'type' : param.type,
+               'level': param.level,
                'description' : param.description,
                'edit_method' : param.edit_method,
             })


### PR DESCRIPTION
The level of the ParamDescription(s) should also be inserted into the decoded description
