### PR TITLE
package.xml: tuned whitespaces

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -6,7 +6,7 @@
     node parameters at any time without having to restart the node.
   </description>
   <maintainer email="zklapow@willowgarage.com">Ze'ev Klapow</maintainer>
-  <license>BSD</license>  
+  <license>BSD</license>
 
   <url>http://ros.org/wiki/dynamic_reconfigure</url>
   <author>Blaise Gassend</author>


### PR DESCRIPTION
This commit removes trailing whitespaces and makes the line with the license information in the package.xml bitwise match exactly the common license information line in most ROS packages.
The trailing whitespaces were detected when providing a bitbake recipe in the meta-ros project (github.com/bmwcarit/meta-ros). In the recipe, the hash of the license line is declared and is used to check for changes in the license. For this recipe, it was not matching the common one.
