### PR TITLE
Removing superfluous 'execute_process' command which always runs even when the cfg file doesn't change.

### DIFF
--- a/cmake/extras.cmake.em
+++ b/cmake/extras.cmake.em
@@ -41,17 +41,6 @@ macro(generate_dynamic_reconfigure_options)
       ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}
     )
     debug_message(2 "dynamic reconfigure cmd: ${_cmd}")
-    execute_process(COMMAND ${_cmd}
-                    RESULT_VARIABLE RES_VAR
-                    OUTPUT_VARIABLE OUT_VAR
-                    ERROR_VARIABLE ERR_VAR
-                    OUTPUT_STRIP_TRAILING_WHITESPACE
-                    ERROR_STRIP_TRAILING_WHITESPACE
-    )
-    if(${RES_VAR} OR NOT "${ERR_VAR}" STREQUAL "")
-      message(FATAL_ERROR "Could not run dynamic reconfigure file '${_cfg}': ${ERR_VAR}")
-    endif()
-    message(STATUS "dynamic_reconfigure built ${_cfg}: ${OUT_VAR}")
 
     #file(WRITE ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}/cfg/__init__.py)
 


### PR DESCRIPTION
Currently, dynamic_reconfigure will _always_ re-generate files when cmake configure is run. This Causes a LOT of unnecessary re-compilation. Furthermore, it looks like the configure files are being generated twice when they need to be. This patch removes the 'execute_process' cmake command which runs the same exact command as the 'add_custom_command' cmake command that appears a few lines below.
