### PR TITLE
Do not use shared libraries on Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ catkin_package(LIBRARIES dynamic_reconfigure_config_init_mutex
                CFG_EXTRAS dynamic_reconfigure-extras.cmake
 )
 
-add_library(dynamic_reconfigure_config_init_mutex SHARED
+add_library(dynamic_reconfigure_config_init_mutex
   src/dynamic_reconfigure_config_init_mutex.cpp)
 target_link_libraries(dynamic_reconfigure_config_init_mutex ${Boost_LIBRARIES})
 


### PR DESCRIPTION
This is needed for cross-compiling ROS to run on Android devices as we need to use static libraries. Similar to https://github.com/ros/class_loader/pull/20

Is there a specific reason why this lib needs to be hard-coded as shared? I've added the if clause to avoid breaking something else but, as catkin_make's default behavior is to build shared libraries, this seems redundant and maybe we can omit it, or is there something else I'm not considering?

Thanks!
