### PR TITLE
Fix group configuration updates

### DIFF
--- a/src/dynamic_reconfigure/client.py
+++ b/src/dynamic_reconfigure/client.py
@@ -232,7 +232,7 @@ class Client(object):
 
         groups = []
         def update_state(group, description):
-            for p,g in enumerate(description['groups']):
+            for p,g in description['groups'].items():
                 if g['name'] == group:
                     description['groups'][p]['state'] = changes[group]
                 else:


### PR DESCRIPTION
Not sure where this went wrong, but the code certainly doesn't work as-is. I just exposed this bug while re-enabling group support in `rqt_reconfigure` (https://github.com/ros-visualization/rqt_common_plugins/pull/287)

Thanks,

--scott
