### PR TITLE
back to unicode in decode_config

### DIFF
--- a/src/dynamic_reconfigure/encoding.py
+++ b/src/dynamic_reconfigure/encoding.py
@@ -275,6 +275,12 @@ def initial_config(msg, description = None):
     return d 
 
 def decode_config(msg, description = None):
+    if sys.version < '3':
+        for s in msg.strs:
+            try:
+                s.value.decode('ascii')
+            except UnicodeDecodeError:
+                s.value=s.value.decode('utf-8')
     d = Config([(kv.name, kv.value) for kv in msg.bools + msg.ints + msg.strs + msg.doubles])
     if not msg.groups == [] and description is not None:
         d["groups"] = get_tree(msg)

--- a/test/simple_python_client_test.py
+++ b/test/simple_python_client_test.py
@@ -80,7 +80,21 @@ class TestSimpleDynamicReconfigureClient(unittest.TestCase):
 
         config = client.get_configuration(timeout=5)
 
-        self.assertEqual("いろは", config['mstr_'])
+        self.assertEqual(u"いろは", config['mstr_'])
+        self.assertEqual(u"いろは", rospy.get_param('/ref_server/mstr_'))
+
+        str_ = u"にほへ"
+
+        client.update_configuration(
+            {"mstr_": str_}
+        )
+
+        rospy.sleep(1.0)
+
+        config = client.get_configuration(timeout=5)
+
+        self.assertEqual(u"にほへ", config['mstr_'])
+        self.assertEqual(u"にほへ", rospy.get_param('/ref_server/mstr_'))
 
 if __name__ == "__main__":
     import rostest


### PR DESCRIPTION
I fixed the code to work like

```
client.update_configuration({"mstr_": u"いろは"} )
config = client.get_configuration(timeout=5)
self.assertEqual(u"いろは", config['mstr_'])
```

 if you set reconfigure param in unicode, then you'll get them using unicode
see 
https://github.com/ros/dynamic_reconfigure/pull/45/files#diff-326aeceb164c22eb7839ff7094d2f850L83
for test code
