### PR TITLE
Ensure that dynamic_reconfigure returns unicode strings

### DIFF
--- a/src/dynamic_reconfigure/client.py
+++ b/src/dynamic_reconfigure/client.py
@@ -201,7 +201,7 @@ class Client(object):
                                     changes[name] = val_type(const['value'])
                                     found = True
                         if not found:
-                            if sys.version < '3':
+                            if sys.version_info.major < 3:
                                 if type(value) is unicode:
                                     changes[name] = unicode(value)
                                 else:

--- a/src/dynamic_reconfigure/encoding.py
+++ b/src/dynamic_reconfigure/encoding.py
@@ -116,7 +116,8 @@ def encode_config(config, flat=True):
         if   type(v) == int:   msg.ints.append(IntParameter(k, v))
         elif type(v) == bool:  msg.bools.append(BoolParameter(k, v))
         elif type(v) == str:   msg.strs.append(StrParameter(k, v))
-        elif sys.version < '3' and type(v) == unicode:   msg.strs.append(StrParameter(k, v))
+        elif sys.version_info.major < 3 and type(v) == unicode:
+            msg.strs.append(StrParameter(k, v))
         elif type(v) == float: msg.doubles.append(DoubleParameter(k, v))
         elif type(v) == dict or isinstance(v, Config):
             if flat is True:
@@ -276,6 +277,14 @@ def initial_config(msg, description = None):
     return d 
 
 def decode_config(msg, description = None):
+    if sys.version_info.major < 3:
+        for s in msg.strs:
+            if not isinstance(s.value, unicode):
+                try:
+                    s.value.decode('ascii')
+                except UnicodeDecodeError:
+                    s.value = s.value.decode('utf-8')
+
     d = Config([(kv.name, kv.value) for kv in msg.bools + msg.ints + msg.strs + msg.doubles])
     if not msg.groups == [] and description is not None:
         d["groups"] = get_tree(msg)

--- a/test/simple_python_client_test.py
+++ b/test/simple_python_client_test.py
@@ -63,6 +63,7 @@ class TestSimpleDynamicReconfigureClient(unittest.TestCase):
         self.assertEqual(int_, config['int_'])
         self.assertEqual(double_, config['double_'])
         self.assertEqual(str_, config['str_'])
+        self.assertEqual(type(str_), type(config['str_']))
         self.assertEqual(bool_, config['bool_'])
 
     def testmultibytestring(self):
@@ -70,7 +71,8 @@ class TestSimpleDynamicReconfigureClient(unittest.TestCase):
         config = client.get_configuration(timeout=5)
         self.assertEqual('bar', config['mstr_'])
 
-        str_ = u"いろは"
+        # Kanji for konnichi wa (hello)
+        str_ = u"今日は"
 
         client.update_configuration(
             {"mstr_": str_}
@@ -80,7 +82,24 @@ class TestSimpleDynamicReconfigureClient(unittest.TestCase):
 
         config = client.get_configuration(timeout=5)
 
-        self.assertEqual("いろは", config['mstr_'])
+        self.assertEqual(u"今日は", config['mstr_'])
+        self.assertEqual(type(u"今日は"), type(config['mstr_']))
+        self.assertEqual(u"今日は", rospy.get_param('/ref_server/mstr_'))
+
+        # Hiragana for konnichi wa (hello)
+        str_ = u"こんにちは"
+
+        client.update_configuration(
+            {"mstr_": str_}
+        )
+
+        rospy.sleep(1.0)
+
+        config = client.get_configuration(timeout=5)
+
+        self.assertEqual(u"こんにちは", config['mstr_'])
+        self.assertEqual(type(u"こんにちは"), type(config['mstr_']))
+        self.assertEqual(u"こんにちは", rospy.get_param('/ref_server/mstr_'))
 
 if __name__ == "__main__":
     import rostest


### PR DESCRIPTION
Ensure that dynamic_reconfigure returns unicode strings and fix code to work for Python 3
