### PR TITLE
fixes #35 by setting queue_size to 10 for publishers.

### DIFF
--- a/src/dynamic_reconfigure/server.py
+++ b/src/dynamic_reconfigure/server.py
@@ -68,10 +68,10 @@ class Server(object):
         self.config['groups'] = get_tree(self.description)
         self.config = initial_config(encode_config(self.config), type.config_description)
 
-        self.descr_topic = rospy.Publisher('~parameter_descriptions', ConfigDescrMsg, latch=True)
+        self.descr_topic = rospy.Publisher('~parameter_descriptions', ConfigDescrMsg, latch=True, queue_size=10)
         self.descr_topic.publish(self.description);
         
-        self.update_topic = rospy.Publisher('~parameter_updates', ConfigMsg, latch=True)
+        self.update_topic = rospy.Publisher('~parameter_updates', ConfigMsg, latch=True, queue_size=10)
         self._change_config(self.config, type.all_level)
         
         self.set_service = rospy.Service('~set_parameters', ReconfigureSrv, self._set_callback)


### PR DESCRIPTION
This removes the warning that's printed out in Indigo. I chose a default value for queue_size as 10 as per @ibaranov-cp's suggestion in issue #35.
