### PR TITLE
fix Python environment to make it work on the first run

### DIFF
--- a/cmake/dynamic_reconfigure-macros.cmake
+++ b/cmake/dynamic_reconfigure-macros.cmake
@@ -28,7 +28,9 @@ macro(generate_dynamic_reconfigure_options)
     set(_output_usage ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/docs/${_cfgonly}Config-usage.dox) 
 
     assert(CATKIN_ENV)
-    set(_cmd ${CATKIN_ENV}
+    set(_cmd
+      PYTHONPATH=${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_PYTHON_DESTINATION}:$ENV{PYTHONPATH}
+      ${CATKIN_ENV}
       ${_input}
       ${dynamic_reconfigure_BASE_DIR}
       ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}


### PR DESCRIPTION
This should fix the build failures of the Kinetic jobs: http://build.ros.org/view/Kbin_uX64/job/Kbin_uX64__dynamic_reconfigure__ubuntu_xenial_amd64__binary/1/