### PR TITLE
add devel space to Python environment to allow .cfg files to import them

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package dynamic_reconfigure
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* add devel space to Python environment to allow .cfg files to import them `#60 <https://github.com/ros/dynamic_reconfigure/issues/60>`_
+* Contributors: Dirk Thomas
+
 1.5.42 (2016-03-15)
 -------------------
 * fix Python environment to make it work on the first run `#59 <https://github.com/ros/dynamic_reconfigure/issues/59>`_

--- a/cmake/dynamic_reconfigure-macros.cmake
+++ b/cmake/dynamic_reconfigure-macros.cmake
@@ -27,10 +27,10 @@ macro(generate_dynamic_reconfigure_options)
     set(_output_wikidoc ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/docs/${_cfgonly}Config.wikidoc)
     set(_output_usage ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/docs/${_cfgonly}Config-usage.dox) 
 
-    # in case dynamic_reconfigure has been built within the same CMake context
-    # we need to explicitly add it to the PYTHONPATH
+    # we need to explicitly add the devel space to the PYTHONPATH
+    # since it might contain dynamic_reconfigure or Python code of the current package
     set("_CUSTOM_PYTHONPATH_ENV")
-    if(EXISTS "${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_PYTHON_DESTINATION}/dynamic_reconfigure")
+    if(EXISTS "${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_PYTHON_DESTINATION}")
       configure_file(
         "${dynamic_reconfigure_BASE_DIR}/cmake/setup_custom_pythonpath.sh.in"
         "setup_custom_pythonpath.sh"


### PR DESCRIPTION
This is currently failing a lot of jobs on the farm:
* http://build.ros.org/job/Jbin_uT32__jsk_tilt_laser__ubuntu_trusty_i386__binary/8/
* http://build.ros.org/job/Jbin_uT32__image_view2__ubuntu_trusty_i386__binary/4/
* http://build.ros.org/job/Jbin_uT32__opt_camera__ubuntu_trusty_i386__binary/4/
* http://build.ros.org/job/Jbin_uT32__dynamic_tf_publisher__ubuntu_trusty_i386__binary/2/
* http://build.ros.org/job/Jbin_uT32__mini_maxwell__ubuntu_trusty_i386__binary/2/
* http://build.ros.org/job/Jbin_uT32__jsk_network_tools__ubuntu_trusty_i386__binary/2/
* http://build.ros.org/job/Jbin_uT64__dynamic_tf_publisher__ubuntu_trusty_amd64__binary/2/
* http://build.ros.org/job/Jbin_uT64__jsk_network_tools__ubuntu_trusty_amd64__binary/2/
* http://build.ros.org/job/Jbin_uT64__mini_maxwell__ubuntu_trusty_amd64__binary/2/
* http://build.ros.org/job/Jbin_uU64__naoqi_sensors_py__ubuntu_utopic_amd64__binary/3/