### PR TITLE
fix issue #51 reloading parameters from dumped file

### DIFF
--- a/src/dynamic_reconfigure/client.py
+++ b/src/dynamic_reconfigure/client.py
@@ -178,7 +178,7 @@ class Client(object):
         # Cast the parameters to the appropriate types
         if self.param_description is not None:
             for name, value in list(changes.items())[:]:
-                if not name is 'groups':
+                if name != 'groups':
                     dest_type = self._param_types.get(name)
                     if dest_type is None:
                         raise DynamicReconfigureParameterException('don\'t know parameter: %s' % name)


### PR DESCRIPTION
In python client when loading the variables the code was checking for object level equality instead of just the string value using the is operator. So replacing the is operator with != fixes the problem.

To test that this is the problem just print the ids of the name variable and 'groups' string