### PR TITLE
address gcc6 build error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,7 @@ project(dynamic_reconfigure)
 find_package(catkin REQUIRED COMPONENTS message_generation roscpp std_msgs)
 find_package(Boost REQUIRED COMPONENTS system thread)
 
-include_directories(include ${catkin_INCLUDE_DIRS})
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 catkin_python_setup()
 


### PR DESCRIPTION
With gcc6, compiling fails with `stdlib.h: No such file or directory`, as including '-isystem /usr/include' breaks with gcc6, cf., https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129.

This commit addresses this issue for this package in the same way it was addressed in various other ROS packages. A list of related commits and pull requests is at https://github.com/ros/rosdistro/issues/12783.