### PR TITLE
Add a wrapper class with locking

### DIFF
--- a/src/dynamic_reconfigure/parameter_generator.py
+++ b/src/dynamic_reconfigure/parameter_generator.py
@@ -468,7 +468,15 @@ $i.desc=$description $range"""
         paramdescr = []
         groups = []
         members = []
+        member_getters = []
         constants = []
+
+        getter = \
+        "${ctype} get${camel_name}()\n" \
+        "      {\n" \
+        "        boost::recursive_mutex::scoped_lock lock(mutex_);\n" \
+        "        return config_.${name};\n" \
+        "      }"
 
         for const in self.constants:
             self.appendline(constants, "${cconsttype} ${configname}_${name} = $v;", const, "value")
@@ -480,6 +488,10 @@ $i.desc=$description $range"""
                 paramdescr.append(Template("${configname}Config::GroupDescription<${configname}Config::${class}, ${configname}Config::${parentclass}> ${name}(\"${name}\", \"${type}\", ${parent}, ${id}, ${cstate}, &${configname}Config::${field});").safe_substitute(group.to_dict(), configname = self.name))
             for param in group.parameters:
                 self.appendline(members, "${ctype} ${name};", param)
+                camel_param = param
+                camel_param["camel_name"] = ''.join(x.capitalize() or '_' for x in camel_param["name"].split('_'))
+                self.appendline(member_getters, getter, camel_param)
+
                 self.appendline(paramdescr, "__min__.${name} = $v;", param, "min")
                 self.appendline(paramdescr, "__max__.${name} = $v;", param, "max")
                 self.appendline(paramdescr, "__default__.${name} = $v;", param, "default")
@@ -504,11 +516,13 @@ $i.desc=$description $range"""
 
         paramdescr = string.join(paramdescr, '\n')
         members = string.join(members, '\n')
+        member_getters = '\n'.join(member_getters)
         groups = string.join(groups, '\n')
         constants = string.join(constants, '\n')
         f.write(Template(template).substitute(uname=self.name.upper(), 
             configname=self.name, pkgname = self.pkgname, paramdescr = paramdescr,
-            members = members, groups = groups, doline = LINEDEBUG, constants = constants))
+            members = members, member_getters = member_getters, groups = groups,
+            doline = LINEDEBUG, constants = constants))
         f.close()
 
     def deleteoneobsolete(self, file):

--- a/src/dynamic_reconfigure/parameter_generator.py
+++ b/src/dynamic_reconfigure/parameter_generator.py
@@ -471,8 +471,8 @@ $i.desc=$description $range"""
         member_getters = []
         constants = []
 
-        getter = \
-        "${ctype} get${camel_name}()\n" \
+        getter_template = \
+        "${ctype} get${camel_cased_name}()\n" \
         "      {\n" \
         "        boost::recursive_mutex::scoped_lock lock(mutex_);\n" \
         "        return config_.${name};\n" \
@@ -488,9 +488,11 @@ $i.desc=$description $range"""
                 paramdescr.append(Template("${configname}Config::GroupDescription<${configname}Config::${class}, ${configname}Config::${parentclass}> ${name}(\"${name}\", \"${type}\", ${parent}, ${id}, ${cstate}, &${configname}Config::${field});").safe_substitute(group.to_dict(), configname = self.name))
             for param in group.parameters:
                 self.appendline(members, "${ctype} ${name};", param)
-                camel_param = param
-                camel_param["camel_name"] = ''.join(x.capitalize() or '_' for x in camel_param["name"].split('_'))
-                self.appendline(member_getters, getter, camel_param)
+                
+                #construct temporary parameters with camel-cased name; e.g.: some_parameter_name -> someParameterName
+                parameters_with_camel_cased_name = param
+                parameters_with_camel_cased_name["camel_cased_name"] = ''.join(x.capitalize() or '_' for x in parameters_with_camel_cased_name["name"].split('_'))
+                self.appendline(member_getters, getter_template, parameters_with_camel_cased_name)
 
                 self.appendline(paramdescr, "__min__.${name} = $v;", param, "min")
                 self.appendline(paramdescr, "__max__.${name} = $v;", param, "max")

--- a/src/dynamic_reconfigure/parameter_generator.py
+++ b/src/dynamic_reconfigure/parameter_generator.py
@@ -472,10 +472,11 @@ $i.desc=$description $range"""
         constants = []
 
         getter_template = \
-        "${ctype} get${camel_cased_name}()\n" \
+        "/** @brief Locking (thread safe) getter */\n" \
+        "      ${ctype} get${camel_cased_name}()\n" \
         "      {\n" \
         "        boost::recursive_mutex::scoped_lock lock(mutex_);\n" \
-        "        return config_.${name};\n" \
+        "        return ${name};\n" \
         "      }"
 
         for const in self.constants:

--- a/src/dynamic_reconfigure/parameter_generator_catkin.py
+++ b/src/dynamic_reconfigure/parameter_generator_catkin.py
@@ -475,10 +475,11 @@ $i.desc=$description $range"""
         constants = []
 
         getter_template = \
-        "${ctype} get${camel_cased_name}()\n" \
+        "/** @brief Locking (thread safe) getter */\n" \
+        "      ${ctype} get${camel_cased_name}()\n" \
         "      {\n" \
         "        boost::recursive_mutex::scoped_lock lock(mutex_);\n" \
-        "        return config_.${name};\n" \
+        "        return ${name};\n" \
         "      }"
 
         for const in self.constants:

--- a/src/dynamic_reconfigure/parameter_generator_catkin.py
+++ b/src/dynamic_reconfigure/parameter_generator_catkin.py
@@ -474,8 +474,8 @@ $i.desc=$description $range"""
         member_getters = []
         constants = []
 
-        getter = \
-        "${ctype} get${camel_name}()\n" \
+        getter_template = \
+        "${ctype} get${camel_cased_name}()\n" \
         "      {\n" \
         "        boost::recursive_mutex::scoped_lock lock(mutex_);\n" \
         "        return config_.${name};\n" \
@@ -491,9 +491,11 @@ $i.desc=$description $range"""
                 paramdescr.append(Template("${configname}Config::GroupDescription<${configname}Config::${class}, ${configname}Config::${parentclass}> ${name}(\"${name}\", \"${type}\", ${parent}, ${id}, ${cstate}, &${configname}Config::${field});").safe_substitute(group.to_dict(), configname = self.name))
             for param in group.parameters:
                 self.appendline(members, "${ctype} ${name};", param)
-                camel_param = param
-                camel_param["camel_name"] = ''.join(x.capitalize() or '_' for x in camel_param["name"].split('_'))
-                self.appendline(member_getters, getter, camel_param)
+                
+                #construct temporary parameters with camel-cased name; e.g.: some_parameter_name -> someParameterName
+                parameters_with_camel_cased_name = param
+                parameters_with_camel_cased_name["camel_cased_name"] = ''.join(x.capitalize() or '_' for x in parameters_with_camel_cased_name["name"].split('_'))
+                self.appendline(member_getters, getter_template, parameters_with_camel_cased_name)
 
                 self.appendline(paramdescr, "__min__.${name} = $v;", param, "min")
                 self.appendline(paramdescr, "__max__.${name} = $v;", param, "max")

--- a/templates/ConfigType.h.template
+++ b/templates/ConfigType.h.template
@@ -18,6 +18,7 @@ ${doline} ${linenum} "${filename}"
 #include <dynamic_reconfigure/Group.h>
 #include <dynamic_reconfigure/config_init_mutex.h>
 #include <boost/any.hpp>
+#include <boost/thread/recursive_mutex.hpp>
 
 namespace ${pkgname}
 {
@@ -335,6 +336,77 @@ ${doline} ${linenum} "${filename}"
   private:
     static const ${configname}ConfigStatics *__get_statics__();
   };
+  
+  typedef boost::shared_ptr<${configname}Config> ${configname}ConfigPtr;
+
+  class ${configname}ConfigLocking
+  {
+    public:
+      ${configname}ConfigLocking()
+      {
+      }
+
+      ${configname}ConfigLocking(const ${configname}Config& config) : config_(config)
+      {
+      }
+
+      ${configname}ConfigLocking(const ${configname}ConfigLocking& copied_config)
+      {
+          config_ = copied_config.config_;
+      }
+
+      bool __fromMessage__(dynamic_reconfigure::Config &msg)
+      {
+          boost::recursive_mutex::scoped_lock lock(mutex_);
+          return config_.__fromMessage__(msg);
+      }
+
+      void __toMessage__(dynamic_reconfigure::Config &msg,
+                  const std::vector<${configname}Config::AbstractParamDescriptionConstPtr> &__param_descriptions__,
+                  const std::vector<${configname}Config::AbstractGroupDescriptionConstPtr> &__group_descriptions__)
+      {
+          boost::recursive_mutex::scoped_lock lock(mutex_);
+          config_.__toMessage__(msg, __param_descriptions__, __group_descriptions__);
+      }
+
+      void __toMessage__(dynamic_reconfigure::Config &msg)
+      {
+          boost::recursive_mutex::scoped_lock lock(mutex_);
+          config_.__toMessage__(msg);
+      }
+
+      void __toServer__(const ros::NodeHandle &nh)
+      {
+          boost::recursive_mutex::scoped_lock lock(mutex_);
+          config_.__toServer__(nh);
+      }
+
+      void __fromServer__(const ros::NodeHandle &nh)
+      {
+          boost::recursive_mutex::scoped_lock lock(mutex_);
+          config_.__fromServer__(nh);
+      }
+
+      void __clamp__()
+      {
+          boost::recursive_mutex::scoped_lock lock(mutex_);
+          config_.__clamp__();
+      }
+
+      uint32_t __level__(const ${configname}Config &config)
+      {
+          boost::recursive_mutex::scoped_lock lock(mutex_);
+          return config_.__level__(config);
+      }
+
+      ${member_getters}
+
+    protected:
+      ${configname}Config config_;
+      boost::recursive_mutex mutex_;
+  };
+
+  typedef boost::shared_ptr<${configname}ConfigLocking> ${configname}ConfigLockingPtr;
   
   template <> // Max and min are ignored for strings.
   inline void ${configname}Config::ParamDescription<std::string>::clamp(${configname}Config &config, const ${configname}Config &max, const ${configname}Config &min) const

--- a/templates/ConfigType.h.template
+++ b/templates/ConfigType.h.template
@@ -336,21 +336,45 @@ ${doline} ${linenum} "${filename}"
   private:
     static const ${configname}ConfigStatics *__get_statics__();
   };
-  
   typedef boost::shared_ptr<${configname}Config> ${configname}ConfigPtr;
 
-  class ${configname}ConfigLocking
+
+  /**
+  * @brief A ${configname}Config with thread safe functions
+  *
+  * This class wraps a ${configname}Config and exposes the parameters
+  * with locking getter functions.
+  * Other functions (__fromMessage__, __toMessage__) are also locking.
+  *
+  * This allows using the same instance in the dynamic reconfigure
+  * callback and other parts of your class running in a different
+  * thread without additional locking.
+  *
+  */
+  class ${configname}LockingConfig
   {
     public:
-      ${configname}ConfigLocking()
+      ${configname}LockingConfig()
       {
       }
 
-      ${configname}ConfigLocking(const ${configname}Config& config) : config_(config)
+      /**
+      * @brief Constructor wrapping a copy of a given ${configname}Config
+      *
+      * @param config : Config getting copied for wrapping.
+      */
+      ${configname}LockingConfig(const ${configname}Config& config) : config_(config)
       {
       }
-
-      ${configname}ConfigLocking(const ${configname}ConfigLocking& copied_config)
+      
+      /**
+      * @brief Copy constructor
+      *
+      * Instanciate its own mutex
+      *
+      * @param config : Config getting copied for wrapping.
+      */
+      ${configname}LockingConfig(const ${configname}LockingConfig& copied_config)
       {
           config_ = copied_config.config_;
       }
@@ -405,8 +429,8 @@ ${doline} ${linenum} "${filename}"
       ${configname}Config config_;
       boost::recursive_mutex mutex_;
   };
+  typedef boost::shared_ptr<${configname}LockingConfig> ${configname}LockingConfigPtr;
 
-  typedef boost::shared_ptr<${configname}ConfigLocking> ${configname}ConfigLockingPtr;
   
   template <> // Max and min are ignored for strings.
   inline void ${configname}Config::ParamDescription<std::string>::clamp(${configname}Config &config, const ${configname}Config &max, const ${configname}Config &min) const

--- a/templates/ConfigType.h.template
+++ b/templates/ConfigType.h.template
@@ -346,9 +346,9 @@ ${doline} ${linenum} "${filename}"
   * with locking getter functions.
   * Other functions (__fromMessage__, __toMessage__) are also locking.
   *
-  * This allows using the same instance in the dynamic reconfigure
-  * callback and other parts of your class running in a different
-  * thread without additional locking.
+  * This allows using the same object in the dynamic reconfigure
+  * callback and other parts of your class (which are probably running
+  * in a different thread) without additional locking.
   *
   */
   class ${configname}LockingConfig
@@ -370,7 +370,7 @@ ${doline} ${linenum} "${filename}"
       /**
       * @brief Copy constructor
       *
-      * Instanciate its own mutex
+      * Instanciates its own mutex
       *
       * @param config : Config getting copied for wrapping.
       */

--- a/templates/ConfigType.h.template
+++ b/templates/ConfigType.h.template
@@ -342,28 +342,19 @@ ${doline} ${linenum} "${filename}"
   /**
   * @brief A ${configname}Config with thread safe functions
   *
-  * This class wraps a ${configname}Config and exposes the parameters
-  * with locking getter functions.
-  * Other functions (__fromMessage__, __toMessage__) are also locking.
+  * This class is like ${configname}Config but adds locking getters
+  * for the parameters and locking versions of the functions
+  * ("__functionName_locking__").
   *
   * This allows using the same object in the dynamic reconfigure
   * callback and other parts of your class (which are probably running
   * in a different thread) without additional locking.
   *
   */
-  class ${configname}LockingConfig
+  class ${configname}LockingConfig : ${configname}Config
   {
     public:
-      ${configname}LockingConfig()
-      {
-      }
-
-      /**
-      * @brief Constructor wrapping a copy of a given ${configname}Config
-      *
-      * @param config : Config getting copied for wrapping.
-      */
-      ${configname}LockingConfig(const ${configname}Config& config) : config_(config)
+      ${configname}LockingConfig() : ${configname}Config()
       {
       }
       
@@ -372,61 +363,59 @@ ${doline} ${linenum} "${filename}"
       *
       * Instanciates its own mutex
       *
-      * @param config : Config getting copied for wrapping.
+      * @param config : Config getting copied
       */
-      ${configname}LockingConfig(const ${configname}LockingConfig& copied_config)
+      ${configname}LockingConfig(const ${configname}LockingConfig& copied_config) : ${configname}Config(copied_config)
       {
-          config_ = copied_config.config_;
       }
 
-      bool __fromMessage__(dynamic_reconfigure::Config &msg)
+      bool __fromMessage_locking__(dynamic_reconfigure::Config &msg)
       {
           boost::recursive_mutex::scoped_lock lock(mutex_);
-          return config_.__fromMessage__(msg);
+          return ${configname}Config::__fromMessage__(msg);
       }
 
-      void __toMessage__(dynamic_reconfigure::Config &msg,
+      void __toMessage_locking__(dynamic_reconfigure::Config &msg,
                   const std::vector<${configname}Config::AbstractParamDescriptionConstPtr> &__param_descriptions__,
                   const std::vector<${configname}Config::AbstractGroupDescriptionConstPtr> &__group_descriptions__)
       {
           boost::recursive_mutex::scoped_lock lock(mutex_);
-          config_.__toMessage__(msg, __param_descriptions__, __group_descriptions__);
+          ${configname}Config::__toMessage__(msg, __param_descriptions__, __group_descriptions__);
       }
 
-      void __toMessage__(dynamic_reconfigure::Config &msg)
+      void __toMessage_locking__(dynamic_reconfigure::Config &msg)
       {
           boost::recursive_mutex::scoped_lock lock(mutex_);
-          config_.__toMessage__(msg);
+          ${configname}Config::__toMessage__(msg);
       }
 
-      void __toServer__(const ros::NodeHandle &nh)
+      void __toServer_locking__(const ros::NodeHandle &nh)
       {
           boost::recursive_mutex::scoped_lock lock(mutex_);
-          config_.__toServer__(nh);
+          ${configname}Config::__toServer__(nh);
       }
 
-      void __fromServer__(const ros::NodeHandle &nh)
+      void __fromServer_locking__(const ros::NodeHandle &nh)
       {
           boost::recursive_mutex::scoped_lock lock(mutex_);
-          config_.__fromServer__(nh);
+          ${configname}Config::__fromServer__(nh);
       }
 
-      void __clamp__()
+      void __clamp_locking__()
       {
           boost::recursive_mutex::scoped_lock lock(mutex_);
-          config_.__clamp__();
+          ${configname}Config::__clamp__();
       }
 
-      uint32_t __level__(const ${configname}Config &config)
+      uint32_t __level_locking__(const ${configname}Config &config)
       {
           boost::recursive_mutex::scoped_lock lock(mutex_);
-          return config_.__level__(config);
+          return ${configname}Config::__level__(config);
       }
 
       ${member_getters}
 
     protected:
-      ${configname}Config config_;
       boost::recursive_mutex mutex_;
   };
   typedef boost::shared_ptr<${configname}LockingConfig> ${configname}LockingConfigPtr;


### PR DESCRIPTION
Currently locking for the config objects needs to be done by the class using it. This is a pain in the ass if you share it between multiple objects. 
Writing a wrapper class outside of dynamic_reconfiguring is also problematic, as it has to be edited every time a parameter gets changed or added.

This adds an automatically generated wrapper class. It uses a boost mutex inside and makes the config parameters accessible with locking getter functions.
