### PR TITLE
Add missing group params to wikidoc

### DIFF
--- a/src/dynamic_reconfigure/parameter_generator_catkin.py
+++ b/src/dynamic_reconfigure/parameter_generator_catkin.py
@@ -340,7 +340,7 @@ group.0 {
 name=Dynamically Reconfigurable Parameters
 desc=See the [[dynamic_reconfigure]] package for details on dynamically reconfigurable parameters.""", file=f)
         i=-1
-        for param in self.group.parameters:
+        for param in self.group.get_parameters():
             i=i+1
             range = ""
             try:


### PR DESCRIPTION
The catkin generated wikidoc files were missing parameters defined as groups.
Both the Dox and UsageDox file were generated correctly, but the wikidoc was
using the wrong method to traverse all groups.