### PR TITLE
return the right callback in " get_description_callback"

### DIFF
--- a/src/dynamic_reconfigure/client.py
+++ b/src/dynamic_reconfigure/client.py
@@ -278,7 +278,7 @@ class Client(object):
         """
         Get the current description_callback
         """
-        return self._config_callback
+        return self._description_callback
 
     def set_description_callback(self, value):
         """


### PR DESCRIPTION
While this is an obvious bug. We may want to branch out and merge this only in future ROS distributions because the risk of people relying on a wrong behavior that has been in for so long is high.

Note: the description callback has been branded as "experimental" and "do not use" since the first implementation

@ros/ros_team What do you think about this? should this wait until the next ROS distribution and throw a very loud warning in all the existing ones?