### PR TITLE
handle infinity in python generation, fixes #71

### DIFF
--- a/cfg/Test.cfg
+++ b/cfg/Test.cfg
@@ -49,7 +49,9 @@ gen.const("ExtraLarge", int_t, 3, "An extra large value") ], "An enum to set the
 
 gen.add("int_enum_", int_t, 1, "Int enum",0, 0, 3, edit_method = enum)
 gen.add("int_", int_t, 1, "Int parameter",0, -10, 10)
-gen.add("double_", double_t, 2, "double parameter",0, -2, 10)
+gen.add("double_", double_t, 2, "double parameter", 0, -2, 10)
+gen.add("double_no_minmax", double_t, 2, "double parameter without boundaries", 1)
+gen.add("double_no_max", double_t, 2, "double parameter without max value", 2, 0)
 gen.add("str_", str_t, 4, "String parameter","foo")
 gen.add("mstr_", str_t, 4, "Multibyte String parameter","bar")
 gen.add("bool_", bool_t, 8, "Boolean parameter",False)
@@ -67,6 +69,7 @@ group2.add("variable", bool_t,0, "A boolean", True)
 group3 = group2.add_group("Group3")
 group3.add("deep_var_int", int_t, 0, "Were very far down now", 0, 0, 3, edit_method = enum)
 group3.add("deep_var_bool", bool_t, 0, "Were even farther down now!!", True)
+group3.add("deep_var_double", double_t, 0, "Were super far down now!!", -1.0)
 
 group12 = gen.add_group("Upper Group 2")
 group12.add("some_param", int_t, 0, "Some param", 20)

--- a/test/simple_python_client_test.py
+++ b/test/simple_python_client_test.py
@@ -36,6 +36,7 @@ import unittest
 import rospy
 import dynamic_reconfigure.client
 
+
 class TestSimpleDynamicReconfigureClient(unittest.TestCase):
 
     def testsimple(self):
@@ -45,15 +46,22 @@ class TestSimpleDynamicReconfigureClient(unittest.TestCase):
         self.assertEqual(0.0, config['double_'])
         self.assertEqual('foo', config['str_'])
         self.assertEqual(False, config['bool_'])
+        self.assertEqual(1.0, config['double_no_minmax'])
+        self.assertEqual(2.0, config['double_no_max'])
+        self.assertEqual(-1.0, config['deep_var_double'])
+
 
         int_ = 7
         double_ = 0.75
         str_ = 'bar'
         bool_ = True
+        double_no_max_ = 1e+300
+        double_no_minmax_ = -1e+300
 
         client.update_configuration(
             {"int_": int_, "double_": double_, "str_": str_,
-             "bool_": bool_}
+             "bool_": bool_,
+             "double_no_max": double_no_max_, "double_no_minmax": double_no_minmax_}
         )
 
         rospy.sleep(1.0)
@@ -65,6 +73,8 @@ class TestSimpleDynamicReconfigureClient(unittest.TestCase):
         self.assertEqual(str_, config['str_'])
         self.assertEqual(type(str_), type(config['str_']))
         self.assertEqual(bool_, config['bool_'])
+        self.assertEqual(double_no_max_, config['double_no_max'])
+        self.assertEqual(double_no_minmax_, config['double_no_minmax'])
 
     def testmultibytestring(self):
         client = dynamic_reconfigure.client.Client("ref_server", timeout=5)


### PR DESCRIPTION
This replaces every occurrence of `std::numeric_limits<double>::infinity()` in the configuration dictionary before dumping it in the python generated file. Fixes #71.
