### PR TITLE
suppress unused-parameter compiler warnings

### DIFF
--- a/templates/ConfigType.h.template
+++ b/templates/ConfigType.h.template
@@ -339,6 +339,9 @@ ${doline} ${linenum} "${filename}"
   template <> // Max and min are ignored for strings.
   inline void ${configname}Config::ParamDescription<std::string>::clamp(${configname}Config &config, const ${configname}Config &max, const ${configname}Config &min) const
   {
+    (void) config;
+    (void) min;
+    (void) max;
     return;
   }
 


### PR DESCRIPTION
...in specialized method implementation `ParamDescription<std::string>::clamp()`.

This is required if user code is compiled with `-Wunused-parameter`, `-Wunused` or `-Wall` options. An alternative solution would be to omit the parameter names from the signature.