### PR TITLE
dont enforce ROS names for constants

### DIFF
--- a/src/dynamic_reconfigure/parameter_generator.py
+++ b/src/dynamic_reconfigure/parameter_generator.py
@@ -256,7 +256,6 @@ class ParameterGenerator:
                 'srcfile' : inspect.getsourcefile(inspect.currentframe().f_back.f_code),
                 'description' : descr
                 }
-        check_name(name)
         check_description(descr)
         self.fill_type(newconst)
         self.check_type(newconst, 'value')

--- a/src/dynamic_reconfigure/parameter_generator_catkin.py
+++ b/src/dynamic_reconfigure/parameter_generator_catkin.py
@@ -276,7 +276,6 @@ Have a nice day
                 'srcfile' : inspect.getsourcefile(inspect.currentframe().f_back.f_code),
                 'description' : descr
                 }
-        check_name(name)
         check_description(descr)
         self.fill_type(newconst)
         self.check_type(newconst, 'value')


### PR DESCRIPTION
Enforcing ROS names on constants (https://github.com/ros/dynamic_reconfigure/pull/74) caused breakage for several packages. This PR reverts it.