### PR TITLE
Reraising DynamicReconfigureCallbackException in case of a failing service call

### DIFF
--- a/src/dynamic_reconfigure/client.py
+++ b/src/dynamic_reconfigure/client.py
@@ -47,8 +47,8 @@ import sys
 import threading
 import time
 import types
-from dynamic_reconfigure import (DynamicReconfigureParameterException,
-                                 DynamicReconfigureCallbackException)
+from dynamic_reconfigure import DynamicReconfigureCallbackException
+from dynamic_reconfigure import DynamicReconfigureParameterException
 from dynamic_reconfigure.srv import Reconfigure as ReconfigureSrv
 from dynamic_reconfigure.msg import Config as ConfigMsg
 from dynamic_reconfigure.msg import ConfigDescription as ConfigDescrMsg

--- a/src/dynamic_reconfigure/client.py
+++ b/src/dynamic_reconfigure/client.py
@@ -47,12 +47,14 @@ import sys
 import threading
 import time
 import types
-from dynamic_reconfigure import DynamicReconfigureParameterException
+from dynamic_reconfigure import (DynamicReconfigureParameterException,
+                                 DynamicReconfigureCallbackException)
 from dynamic_reconfigure.srv import Reconfigure as ReconfigureSrv
 from dynamic_reconfigure.msg import Config as ConfigMsg
 from dynamic_reconfigure.msg import ConfigDescription as ConfigDescrMsg
 from dynamic_reconfigure.msg import IntParameter, BoolParameter, StrParameter, DoubleParameter, ParamDescription
 from dynamic_reconfigure.encoding import *
+from rospy.service import ServiceException
 
 class Client(object):
     """
@@ -216,7 +218,12 @@ class Client(object):
             changes['groups'] = self.update_groups(changes['groups'])
 
         config = encode_config(changes)
-        msg    = self._set_service(config).config
+
+        try:
+            msg    = self._set_service(config).config
+        except ServiceException as e:
+            raise DynamicReconfigureCallbackException('service call failed')
+
         if self.group_description is None:
             self.get_group_descriptions()
         resp   = decode_config(msg, self.group_description)


### PR DESCRIPTION
When trying to call the configuration server rospy raises exceptions in the case of failures. 
Till now these were non-transparent handed over to the calling function of update_configuration.
This makes it easy that those function don't consider to catch these exception and crash.
An example for this is the dynamic_reconfigure rqt widget.
[https://github.com/ros-visualization/rqt_reconfigure/pull/10](https://github.com/ros-visualization/rqt_reconfigure/pull/10)

In the fix I propose not only to catch the ServiceException but also the DynamicReconfigureCallbackException. Doing so it would be easy to see which exceptions can be raised by the function when seeing the code of dynamic_reconfigure. A small further point might be that like this it is not necessary to import exceptions from different packages which reduces the dependencies for the calling program.