### PR TITLE
check group name validity to avoid compilation error later

### DIFF
--- a/src/dynamic_reconfigure/parameter_generator_catkin.py
+++ b/src/dynamic_reconfigure/parameter_generator_catkin.py
@@ -103,6 +103,7 @@ class ParameterGenerator:
 
         def __init__(self, gen, name, type, state, id, parent):
             self.name = name.replace(" ", "_")
+            check_name(self.name)
             self.type = type
             self.groups = []
             self.parameters = []


### PR DESCRIPTION
otherwise we generate invalid c++ class names resulting in compilation errors (see #96)