### PR TITLE
Added virtual destructor for AbstractParamDescription

### DIFF
--- a/templates/ConfigType.h.template
+++ b/templates/ConfigType.h.template
@@ -125,7 +125,7 @@ namespace ${pkgname}
       virtual bool fromMessage(const dynamic_reconfigure::Config &msg, boost::any &config) const =0;
       virtual void updateParams(boost::any &cfg, ${configname}Config &top) const= 0;
       virtual void setInitialState(boost::any &cfg) const = 0;
-      
+
       virtual ~AbstractGroupDescription() {}
 
       void convertParams()

--- a/templates/ConfigType.h.template
+++ b/templates/ConfigType.h.template
@@ -46,6 +46,8 @@ namespace ${pkgname}
       virtual bool fromMessage(const dynamic_reconfigure::Config &msg, ${configname}Config &config) const = 0;
       virtual void toMessage(dynamic_reconfigure::Config &msg, const ${configname}Config &config) const = 0;
       virtual void getValue(const ${configname}Config &config, boost::any &val) const = 0;
+
+      virtual ~AbstractParamDescription() {};
     };
 
     typedef boost::shared_ptr<AbstractParamDescription> AbstractParamDescriptionPtr;

--- a/templates/ConfigType.h.template
+++ b/templates/ConfigType.h.template
@@ -47,7 +47,7 @@ namespace ${pkgname}
       virtual void toMessage(dynamic_reconfigure::Config &msg, const ${configname}Config &config) const = 0;
       virtual void getValue(const ${configname}Config &config, boost::any &val) const = 0;
 
-      virtual ~AbstractParamDescription() {};
+      virtual ~AbstractParamDescription() {}
     };
 
     typedef boost::shared_ptr<AbstractParamDescription> AbstractParamDescriptionPtr;
@@ -125,7 +125,8 @@ namespace ${pkgname}
       virtual bool fromMessage(const dynamic_reconfigure::Config &msg, boost::any &config) const =0;
       virtual void updateParams(boost::any &cfg, ${configname}Config &top) const= 0;
       virtual void setInitialState(boost::any &cfg) const = 0;
-
+      
+      virtual ~AbstractGroupDescription() {}
 
       void convertParams()
       {


### PR DESCRIPTION
`AbstractParamDescription` should have a virtual desctructor as it's used as a base for non-empty `ParamDescription<T>` and is deleted through the pointer onto base type instance.