### PR TITLE
Make C++ Config instances have default values in constructor

### DIFF
--- a/src/dynamic_reconfigure/parameter_generator_catkin.py
+++ b/src/dynamic_reconfigure/parameter_generator_catkin.py
@@ -461,6 +461,7 @@ class ParameterGenerator(object):
         # Write the configuration manipulator.
         self.mkdirabs(self.cpp_gen_dir)
         paramdescr = []
+        paraminit = []
         groups = []
         members = []
         constants = []
@@ -473,6 +474,10 @@ class ParameterGenerator(object):
             else:
                 paramdescr.append(Template("${configname}Config::GroupDescription<${configname}Config::${class}, ${configname}Config::${parentclass}> ${name}(\"${name}\", \"${type}\", ${parent}, ${id}, ${cstate}, &${configname}Config::${field});").safe_substitute(group.to_dict(), configname=self.name))
             for param in group.parameters:
+                if len(paraminit) > 0:
+                    self.appendline(paraminit, "${name}($v), ", param, "default")
+                else:
+                    self.appendline(paraminit, " : ${name}($v), ", param, "default")
                 self.appendline(members, "${ctype} ${name};", param)
                 self.appendline(paramdescr, "__min__.${name} = $v;", param, "min")
                 self.appendline(paramdescr, "__max__.${name} = $v;", param, "max")
@@ -501,6 +506,9 @@ class ParameterGenerator(object):
         self.appendgroup(groups, self.group)
 
         paramdescr = '\n'.join(paramdescr)
+        paraminit = ' '.join(paraminit)
+        # chop off trailing ", "
+        paraminit = paraminit[:-2]
         members = '\n'.join(members)
         constants = '\n'.join(constants)
         groups = '\n'.join(groups)
@@ -508,6 +516,7 @@ class ParameterGenerator(object):
             f.write(Template(template).substitute(
                 uname=self.name.upper(),
                 configname=self.name, pkgname=self.pkgname, paramdescr=paramdescr,
+                paraminit=paraminit,
                 members=members, groups=groups, doline=LINEDEBUG, constants=constants))
         print("Wrote header file in " + os.path.join(self.cpp_gen_dir, self.name + "Config.h"))
 

--- a/templates/ConfigType.h.template
+++ b/templates/ConfigType.h.template
@@ -32,6 +32,10 @@ namespace ${pkgname}
   class ${configname}Config
   {
   public:
+    ${configname}Config()
+    ${paraminit}
+    {
+    }
     class AbstractParamDescription : public dynamic_reconfigure::ParamDescription
     {
     public:


### PR DESCRIPTION
This generates a header with an initializer list with all the default values, previously the defaults were loaded in only when the server ran.

This works now:
```
...
gen.add("str_param", str_t, 1, "string", "test")
...
```
```
#include <dynamic_reconfigure_example/ExampleConfig.h>
...
dynamic_reconfigure_example::ExampleConfig config;
ROS_INFO_STREAM(config.str_param);
```

For #33

(There isn't a corresponding class created for python (would that be useful?), the defaults can be accessed currently like this:

```
from dynamic_reconfigure_example.cfg import ExampleConfig
print ExampleConfig.defaults['str_param']
```
)

