### PR TITLE
Add validity checks for range and defaults

### DIFF
--- a/cfg/Test.cfg
+++ b/cfg/Test.cfg
@@ -74,4 +74,24 @@ group3.add("deep_var_double", double_t, 0, "Were super far down now!!", -1.0)
 group12 = gen.add_group("Upper Group 2")
 group12.add("some_param", int_t, 0, "Some param", 20)
 
+try:
+    gen.add("double_invalid_range", double_t, 0, "This should fail for invalid range", 0, 1, -1)
+except Exception:
+    pass
+else:
+    raise Exception("We expected an exception but it worked. There is something wrong with finding an error")
+
+try:
+    gen.add("double_invalid_default_0", double_t, 0, "This should fail for default < min", -1, 0, 1)
+except Exception:
+    pass
+else:
+    raise Exception("We expected an exception but it worked. There is something wrong with finding an error")
+try:
+    gen.add("double_invalid_default_1", double_t, 0, "This should fail for default > max", 2, 0, 1)
+except Exception:
+    pass
+else:
+    raise Exception("We expected an exception but it worked. There is something wrong with finding an error")
+
 exit(gen.generate(PACKAGE, "test_reconfigure_server_cpp", "Test"))

--- a/src/dynamic_reconfigure/parameter_generator_catkin.py
+++ b/src/dynamic_reconfigure/parameter_generator_catkin.py
@@ -62,6 +62,20 @@ double_t = "double"
 id = 0
 
 
+def check_default(name, default, min, max):
+    if min is not None and default < min:
+        raise Exception("The default value for {name} ({default}) is smaller than the specified minimum({min}).".format(name=name, min=min, default=default))
+    if max is not None and default > max:
+        raise Exception("The default value for {name} ({default}) is greater than the specified maximum({max}).".format(name=name, max=max, default=default))
+
+
+def check_range(name, min, max):
+    if min is None or max is None:
+        return
+    if min >= max:
+        raise Exception("No valid range specified for {name}. Minimum {min} is equal to or greater than maximum {max}".format(name=name, min=min, max=max))
+
+
 def check_description(description):
     quotes = ['"', "'"]
     for quote in quotes:
@@ -141,6 +155,9 @@ class ParameterGenerator(object):
             if type == str_t and (max is not None or min is not None):
                 raise Exception("Max or min specified for %s, which is of string type" % name)
             check_name(name)
+            check_range(name, min, max)
+            check_default(name, default, min, max)
+
             self.gen.fill_type(newparam)
             self.gen.check_type_fill_default(newparam, 'default', self.gen.defval[paramtype])
             self.gen.check_type_fill_default(newparam, 'max', self.gen.maxval[paramtype])


### PR DESCRIPTION
a) the range for a parameter is impossible to meet
b) the default is out of range

Having those errors in a cfg file can be tedious work to find/debug