### PR TITLE
Add 'display_name' as new attribute for parameters

### DIFF
--- a/msg/ParamDescription.msg
+++ b/msg/ParamDescription.msg
@@ -3,3 +3,4 @@ string type
 uint32 level
 string description
 string edit_method
+string display_name

--- a/scripts/dynparam
+++ b/scripts/dynparam
@@ -172,6 +172,7 @@ def do_dump():
 
     parser = optparse.OptionParser(usage=usage, prog=NAME)
     add_timeout_option(parser)
+    add_minimaldump_option(parser)
     options, args = parser.parse_args(myargv[2:])
     if len(args) == 0:
         parser.error("invalid arguments. Please specify a node name")
@@ -186,7 +187,12 @@ def do_dump():
     if params is not None:
         f = file(path, 'w')
         try:
-            yaml.dump(params, f)
+            if options.minimal:
+                params2 = dict(params)
+                params2.pop('groups', None)
+                yaml.dump(params2, f, default_flow_style=False)
+            else:
+                yaml.dump(params, f)
             return
         finally:
             f.close()
@@ -206,6 +212,9 @@ def set_params(node, params, timeout=None):
 
 def add_timeout_option(parser):
     parser.add_option('-t', '--timeout', action='store', type='float', default=None, help='timeout in secs')
+
+def add_minimaldump_option(parser):
+    parser.add_option('-m', '--minimal', action='store_true', default=False, dest='minimal', help='dump parameters and values only, no group data')
 
 def print_usage():
     print("""dynparam is a command-line tool for getting, setting, and

--- a/src/dynamic_reconfigure/encoding.py
+++ b/src/dynamic_reconfigure/encoding.py
@@ -101,7 +101,7 @@ def encode_groups(parent, group):
     msg.type = group['type']
 
     for param in group['parameters']:
-        msg.parameters.append(ParamDescription(param['name'], param['type'], param['level'], param['description'], param['edit_method']))
+        msg.parameters.append(ParamDescription(param['name'], param['type'], param['level'], param['description'], param['edit_method'], param['display_name']))
 
     group_list.append(msg)
     for next in group['groups']:
@@ -180,6 +180,7 @@ def decode_description(msg):
                 'level': param.level,
                 'description': param.description,
                 'edit_method': param.edit_method,
+                'display_name': param.display_name,
             })
         return params
 

--- a/src/dynamic_reconfigure/parameter_generator_catkin.py
+++ b/src/dynamic_reconfigure/parameter_generator_catkin.py
@@ -125,7 +125,7 @@ class ParameterGenerator(object):
             self.groups.append(group)
             return group
 
-        def add(self, name, paramtype, level, description, default=None, min=None, max=None, edit_method=""):
+        def add(self, name, paramtype, level, description, default=None, min=None, max=None, edit_method="", display_name=""):
             newparam = {
                 'name': name,
                 'type': paramtype,
@@ -137,6 +137,7 @@ class ParameterGenerator(object):
                 'srcline': inspect.currentframe().f_back.f_lineno,
                 'srcfile': inspect.getsourcefile(inspect.currentframe().f_back.f_code),
                 'edit_method': edit_method,
+                'display_name': display_name,
             }
             if type == str_t and (max is not None or min is not None):
                 raise Exception("Max or min specified for %s, which is of string type" % name)
@@ -287,8 +288,8 @@ Have a nice day
         return repr({'enum': constants, 'enum_description': description})
 
     # Wrap add and add_group for the default group
-    def add(self, name, paramtype, level, description, default=None, min=None, max=None, edit_method=""):
-        self.group.add(name, paramtype, level, description, default, min, max, edit_method)
+    def add(self, name, paramtype, level, description, default=None, min=None, max=None, edit_method="", display_name=""):
+        self.group.add(name, paramtype, level, description, default, min, max, edit_method, display_name)
 
     def add_group(self, name, type="", state=True):
         return self.group.add_group(name, type=type, state=state)

--- a/src/dynamic_reconfigure/parameter_generator_catkin.py
+++ b/src/dynamic_reconfigure/parameter_generator_catkin.py
@@ -70,7 +70,7 @@ def check_description(description):
 
 
 def check_name(name):
-    pattern = r'^[a-zA-Z][a-zA-Z0-9_]*$'
+    pattern = r'^[a-zA-Z][a-zA-Z0-9_/]*$'
     if not re.match(pattern, name):
         raise Exception("The name of field \'%s\' does not follow the ROS naming conventions, see http://wiki.ros.org/ROS/Patterns/Conventions" % name)
 
@@ -125,7 +125,7 @@ class ParameterGenerator(object):
             self.groups.append(group)
             return group
 
-        def add(self, name, paramtype, level, description, default=None, min=None, max=None, edit_method=""):
+        def add(self, name, paramtype, level, description, default=None, min=None, max=None, edit_method="", display_name=""):
             newparam = {
                 'name': name,
                 'type': paramtype,
@@ -137,6 +137,7 @@ class ParameterGenerator(object):
                 'srcline': inspect.currentframe().f_back.f_lineno,
                 'srcfile': inspect.getsourcefile(inspect.currentframe().f_back.f_code),
                 'edit_method': edit_method,
+                'display_name': display_name,
             }
             if type == str_t and (max is not None or min is not None):
                 raise Exception("Max or min specified for %s, which is of string type" % name)
@@ -287,8 +288,8 @@ Have a nice day
         return repr({'enum': constants, 'enum_description': description})
 
     # Wrap add and add_group for the default group
-    def add(self, name, paramtype, level, description, default=None, min=None, max=None, edit_method=""):
-        self.group.add(name, paramtype, level, description, default, min, max, edit_method)
+    def add(self, name, paramtype, level, description, default=None, min=None, max=None, edit_method="", display_name=""):
+        self.group.add(name, paramtype, level, description, default, min, max, edit_method, display_name)
 
     def add_group(self, name, type="", state=True):
         return self.group.add_group(name, type=type, state=state)
@@ -480,11 +481,11 @@ Have a nice day
                     paramdescr,
                     group.to_dict()['name'] +
                     ".abstract_parameters.push_back(${configname}Config::AbstractParamDescriptionConstPtr(new ${configname}Config::ParamDescription<${ctype}>(\"${name}\", \"${type}\", ${level}, "
-                    "\"${description}\", \"${edit_method}\", &${configname}Config::${name})));", param)
+                    "\"${description}\", \"${edit_method}\", \"${display_name}\", &${configname}Config::${name})));", param)
                 self.appendline(
                     paramdescr,
                     "__param_descriptions__.push_back(${configname}Config::AbstractParamDescriptionConstPtr(new ${configname}Config::ParamDescription<${ctype}>(\"${name}\", \"${type}\", ${level}, "
-                    "\"${description}\", \"${edit_method}\", &${configname}Config::${name})));", param)
+                    "\"${description}\", \"${edit_method}\", \"${display_name}\", &${configname}Config::${name})));", param)
 
             for g in group.groups:
                 write_params(g)

--- a/templates/ConfigType.h.template
+++ b/templates/ConfigType.h.template
@@ -30,13 +30,14 @@ namespace ${pkgname}
     {
     public:
       AbstractParamDescription(std::string n, std::string t, uint32_t l,
-          std::string d, std::string e)
+          std::string d, std::string e, std::string dn)
       {
         name = n;
         type = t;
         level = l;
         description = d;
         edit_method = e;
+        display_name = dn;
       }
 
       virtual void clamp(${configname}Config &config, const ${configname}Config &max, const ${configname}Config &min) const = 0;
@@ -56,8 +57,8 @@ namespace ${pkgname}
     {
     public:
       ParamDescription(std::string a_name, std::string a_type, uint32_t a_level,
-          std::string a_description, std::string a_edit_method, T ${configname}Config::* a_f) :
-        AbstractParamDescription(a_name, a_type, a_level, a_description, a_edit_method),
+          std::string a_description, std::string a_edit_method, std::string a_display_name, T ${configname}Config::* a_f) :
+        AbstractParamDescription(a_name, a_type, a_level, a_description, a_edit_method, a_display_name),
         field(a_f)
       {}
 


### PR DESCRIPTION
 * this is intended to be shown in a user interface instead of the raw parameter name
 * compatible with current config definitions as it defaults to an empty string

implements feature #110 

connects to #110 
