### PR TITLE
final-keyword

### DIFF
--- a/templates/ConfigType.h.template
+++ b/templates/ConfigType.h.template
@@ -57,6 +57,8 @@ namespace ${pkgname}
     typedef boost::shared_ptr<AbstractParamDescription> AbstractParamDescriptionPtr;
     typedef boost::shared_ptr<const AbstractParamDescription> AbstractParamDescriptionConstPtr;
 
+    // Final keyword added to class because it has virtual methods and inherits 
+    // from a class with a non-virtual destructor.
     template <class T>
     class ParamDescription DYNAMIC_RECONFIGURE_FINAL : public AbstractParamDescription
     {
@@ -143,6 +145,8 @@ namespace ${pkgname}
     typedef boost::shared_ptr<AbstractGroupDescription> AbstractGroupDescriptionPtr;
     typedef boost::shared_ptr<const AbstractGroupDescription> AbstractGroupDescriptionConstPtr;
 
+    // Final keyword added to class because it has virtual methods and inherits 
+    // from a class with a non-virtual destructor.
     template<class T, class PT>
     class GroupDescription DYNAMIC_RECONFIGURE_FINAL : public AbstractGroupDescription
     {

--- a/templates/ConfigType.h.template
+++ b/templates/ConfigType.h.template
@@ -10,6 +10,12 @@ ${doline} ${linenum} "${filename}"
 #ifndef __${pkgname}__${uname}CONFIG_H__
 #define __${pkgname}__${uname}CONFIG_H__
 
+#if __cplusplus >= 201103L
+#define DYNAMIC_RECONFIGURE_FINAL final
+#else
+#define DYNAMIC_RECONFIGURE_FINAL
+#endif
+
 #include <dynamic_reconfigure/config_tools.h>
 #include <limits>
 #include <ros/node_handle.h>
@@ -52,7 +58,7 @@ namespace ${pkgname}
     typedef boost::shared_ptr<const AbstractParamDescription> AbstractParamDescriptionConstPtr;
 
     template <class T>
-    class ParamDescription : public AbstractParamDescription
+    class ParamDescription DYNAMIC_RECONFIGURE_FINAL : public AbstractParamDescription
     {
     public:
       ParamDescription(std::string a_name, std::string a_type, uint32_t a_level,
@@ -138,7 +144,7 @@ namespace ${pkgname}
     typedef boost::shared_ptr<const AbstractGroupDescription> AbstractGroupDescriptionConstPtr;
 
     template<class T, class PT>
-    class GroupDescription : public AbstractGroupDescription
+    class GroupDescription DYNAMIC_RECONFIGURE_FINAL : public AbstractGroupDescription
     {
     public:
       GroupDescription(std::string a_name, std::string a_type, int a_parent, int a_id, bool a_s, T PT::* a_f) : AbstractGroupDescription(a_name, a_type, a_parent, a_id, a_s), field(a_f)
@@ -429,5 +435,7 @@ ${doline} ${linenum} "${filename}"
 
 ${constants}
 }
+
+#undef DYNAMIC_RECONFIGURE_FINAL
 
 #endif // __${uname}RECONFIGURATOR_H__


### PR DESCRIPTION
Add final keyword to child class since parent has virtual methods and grand parent doesn't have a virtual destructor (it's based on a .msg file). This allows the code to be compiled without warnings by pedantic compilers like clang 6.0 and above.

Has no impact on pre-C++11 compilers.

A minimal program to help understand this issue is as follows:

```
#include <memory>

struct Base
{
  using Ptr = std::shared_ptr<Base>;
  virtual void f() = 0;
};


struct Child /*final*/ : Base
{
  void f()
  {
  }
};

int main()
{
  Child::Ptr c = std::make_shared<Child>();
  c->f();
}
```

compiling this with clang-6.0 gives:

```
jmercer@cpr00549:~/.../scratch$ clang++-6.0 --std=c++11 -Wall main.cpp 
In file included from main.cpp:1:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/memory:63:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/allocator.h:46:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/x86_64-linux-gnu/c++/5.4.0/bits/c++allocator.h:33:
/usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/ext/new_allocator.h:124:29: warning: destructor called on
      non-final 'Child' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
        destroy(_Up* __p) { __p->~_Up(); }
                            ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/alloc_traits.h:542:8: note: in instantiation of function
      template specialization '__gnu_cxx::new_allocator<Child>::destroy<Child>' requested here
        { __a.destroy(__p); }
              ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/shared_ptr_base.h:531:28: note: in instantiation of
      function template specialization 'std::allocator_traits<std::allocator<Child> >::destroy<Child>' requested here
        allocator_traits<_Alloc>::destroy(_M_impl._M_alloc(), _M_ptr());
                                  ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/shared_ptr_base.h:517:2: note: in instantiation of member
      function 'std::_Sp_counted_ptr_inplace<Child, std::allocator<Child>, __gnu_cxx::_S_atomic>::_M_dispose' requested here
        _Sp_counted_ptr_inplace(_Alloc __a, _Args&&... __args)
        ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/shared_ptr_base.h:617:18: note: in instantiation of
      function template specialization 'std::_Sp_counted_ptr_inplace<Child, std::allocator<Child>,
      __gnu_cxx::_S_atomic>::_Sp_counted_ptr_inplace<>' requested here
          ::new (__mem) _Sp_cp_type(std::move(__a),
                        ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/shared_ptr_base.h:1096:14: note: in instantiation of
      function template specialization 'std::__shared_count<__gnu_cxx::_S_atomic>::__shared_count<Child, std::allocator<Child>>'
      requested here
        : _M_ptr(), _M_refcount(__tag, (_Tp*)0, __a,
                    ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/shared_ptr.h:319:4: note: in instantiation of function
      template specialization 'std::__shared_ptr<Child, __gnu_cxx::_S_atomic>::__shared_ptr<std::allocator<Child>>' requested here
        : __shared_ptr<_Tp>(__tag, __a, std::forward<_Args>(__args)...)
          ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/shared_ptr.h:619:14: note: in instantiation of function
      template specialization 'std::shared_ptr<Child>::shared_ptr<std::allocator<Child>>' requested here
      return shared_ptr<_Tp>(_Sp_make_shared_tag(), __a,
             ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/shared_ptr.h:635:19: note: in instantiation of function
      template specialization 'std::allocate_shared<Child, std::allocator<Child>>' requested here
      return std::allocate_shared<_Tp>(std::allocator<_Tp_nc>(),
                  ^
main.cpp:19:23: note: in instantiation of function template specialization 'std::make_shared<Child>' requested here
  Child::Ptr c = std::make_shared<Child>();
                      ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/ext/new_allocator.h:124:35: note: qualify call to silence this
      warning
        destroy(_Up* __p) { __p->~_Up(); }
                                  ^
1 warning generated.
jmercer@cpr00549:~/.../scratch$ 
```




