### PR TITLE
call shutdown to prevent test from hanging

### DIFF
--- a/test/test_client.cpp
+++ b/test/test_client.cpp
@@ -140,5 +140,7 @@ int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   ros::AsyncSpinner spinner(2);
   spinner.start();
-  return RUN_ALL_TESTS();
+  int res = RUN_ALL_TESTS();
+  ros::shutdown();
+  return res;
 }


### PR DESCRIPTION
Fixes #103 