### PR TITLE
fix check preventing range for string and bool parameters

### DIFF
--- a/src/dynamic_reconfigure/parameter_generator_catkin.py
+++ b/src/dynamic_reconfigure/parameter_generator_catkin.py
@@ -139,7 +139,7 @@ class ParameterGenerator(object):
                 'srcfile': inspect.getsourcefile(inspect.currentframe().f_back.f_code),
                 'edit_method': edit_method,
             }
-            if type == str_t and (max is not None or min is not None):
+            if paramtype == str_t and (max is not None or min is not None):
                 raise Exception("Max or min specified for %s, which is of string type" % name)
             check_name(name)
             self.gen.fill_type(newparam)

--- a/src/dynamic_reconfigure/parameter_generator_catkin.py
+++ b/src/dynamic_reconfigure/parameter_generator_catkin.py
@@ -139,8 +139,9 @@ class ParameterGenerator(object):
                 'srcfile': inspect.getsourcefile(inspect.currentframe().f_back.f_code),
                 'edit_method': edit_method,
             }
-            if paramtype == str_t and (max is not None or min is not None):
-                raise Exception("Max or min specified for %s, which is of string type" % name)
+            if (paramtype == str_t or paramtype == bool_t) and (max is not None or min is not None):
+                raise Exception(
+                    "Max or min specified for %s, which is of '%s' type" % (name, paramtype))
             check_name(name)
             self.gen.fill_type(newparam)
             self.gen.check_type_fill_default(newparam, 'default', self.gen.defval[paramtype])


### PR DESCRIPTION
Noticed this when testing https://github.com/ros/dynamic_reconfigure/pull/111.

For example this generated successfully https://github.com/tuw-robotics/tuw_marker_detection/blob/a0a11bcd715a0928d4d4a0a295a82ed79014e69d/tuw_aruco/cfg/ArUco.cfg#L26

Now wit the check fixed:
```
Traceback (most recent call last):
  File "/home/mikael/work/ros/tuw_aruco_ws/src/tuw_marker_detection/tuw_aruco/cfg/ArUco.cfg", line 26, in <module>
    gen.add("marker_dictonary", str_t, 0, "Marker dictonary type", "ARTOOLKITPLUSBCH", "ARUCO", "TAG36h10", edit_method=marker_directory_enum)
  File "/home/mikael/work/ros/ros_base/install_isolated/lib/python2.7/dist-packages/dynamic_reconfigure/parameter_generator_catkin.py", line 290, in add
    self.group.add(name, paramtype, level, description, default, min, max, edit_method)
  File "/home/mikael/work/ros/ros_base/install_isolated/lib/python2.7/dist-packages/dynamic_reconfigure/parameter_generator_catkin.py", line 143, in add
    raise Exception("Max or min specified for %s, which is of string type" % name)
Exception: Max or min specified for marker_dictonary, which is of string type
CMakeFiles/tuw_aruco_gencfg.dir/build.make:63: recipe for target '/home/mikael/work/ros/tuw_aruco_ws/devel_isolated/tuw_aruco/include/tuw_aruco/ArUcoConfig.h' failed

```