### PR TITLE
add dll import and export macros

### DIFF
--- a/include/dynamic_reconfigure/config_init_mutex.h
+++ b/include/dynamic_reconfigure/config_init_mutex.h
@@ -3,9 +3,23 @@
 
 #include <boost/thread/mutex.hpp>
 
+#include <ros/macros.h>
+
+// Import/export for windows dll's and visibility for gcc shared libraries.
+
+#ifdef ROS_BUILD_SHARED_LIBS // ros is being built around shared libraries
+  #ifdef dynamic_reconfigure_config_init_mutex_EXPORTS // we are building a shared lib/dll
+    #define DYNAMIC_RECONFIGURE_CONFIG_INIT_MUTEX_DECL ROS_HELPER_EXPORT
+  #else // we are using shared lib/dll
+    #define DYNAMIC_RECONFIGURE_CONFIG_INIT_MUTEX_DECL ROS_HELPER_IMPORT
+  #endif
+#else // ros is being built around static libraries
+  #define DYNAMIC_RECONFIGURE_CONFIG_INIT_MUTEX_DECL
+#endif
+
 namespace dynamic_reconfigure
 {
-  extern boost::mutex __init_mutex__;
+  extern DYNAMIC_RECONFIGURE_CONFIG_INIT_MUTEX_DECL boost::mutex __init_mutex__;
 }
 
 #endif

--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,7 @@
 
   <buildtool_depend version_gte="0.5.87">catkin</buildtool_depend>
 
+  <build_depend>cpp_common</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>roscpp_serialization</build_depend>
   <build_depend>rostest</build_depend>


### PR DESCRIPTION
- add dll import and export macros by following the instructions [on ROS wiki](http://wiki.ros.org/win_ros/Contributing/Dll%20Exports)
- add `cpp_common` as a dependency for `<ros/macros.h>`