### PR TITLE
Fix GCC8 error when using -Werror=parentheses

### DIFF
--- a/templates/ConfigType.h.template
+++ b/templates/ConfigType.h.template
@@ -69,7 +69,7 @@ namespace ${pkgname}
         field(a_f)
       {}
 
-      T (${configname}Config::* field);
+      T ${configname}Config::* field;
 
       virtual void clamp(${configname}Config &config, const ${configname}Config &max, const ${configname}Config &min) const
       {
@@ -216,7 +216,7 @@ namespace ${pkgname}
         }
       }
 
-      T (PT::* field);
+      T PT::* field;
       std::vector<${configname}Config::AbstractGroupDescriptionConstPtr> groups;
     };
 


### PR DESCRIPTION
The `ConfigType.h.template` defines two fields resulting in errors on compilation with GCC8 looking like the following example:
```
In file included from /home/nlimpert/dev/catkin_ws/src/robot_navigation/dwb_plugins/include/dwb_plugins/kinematic_parameters.h:40,
                 from /home/nlimpert/dev/catkin_ws/src/robot_navigation/dwb_plugins/include/dwb_plugins/velocity_iterator.h:40,
                 from /home/nlimpert/dev/catkin_ws/src/robot_navigation/dwb_plugins/include/dwb_plugins/xy_theta_iterator.h:38,
                 from /home/nlimpert/dev/catkin_ws/src/robot_navigation/dwb_plugins/src/xy_theta_iterator.cpp:35:
/home/nlimpert/dev/catkin_ws/devel_isolated/dwb_plugins/include/dwb_plugins/KinematicParamsConfig.h:64:9: error: unnecessary parentheses in declaration of ‘field’ [-Werror=parentheses]
       T (KinematicParamsConfig::* field);
         ^
/home/nlimpert/dev/catkin_ws/devel_isolated/dwb_plugins/include/dwb_plugins/KinematicParamsConfig.h:209:9: error: unnecessary parentheses in declaration of ‘field’ [-Werror=parentheses]
       T (PT::* field);
         ^
cc1plus: all warnings being treated as errors
make[2]: *** [CMakeFiles/standard_traj_generator.dir/build.make:102: CMakeFiles/standard_traj_generator.dir/src/xy_theta_iterator.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
In file included from /home/nlimpert/dev/catkin_ws/src/robot_navigation/dwb_plugins/include/dwb_plugins/kinematic_parameters.h:40,
                 from /home/nlimpert/dev/catkin_ws/src/robot_navigation/dwb_plugins/include/dwb_plugins/velocity_iterator.h:40,
                 from /home/nlimpert/dev/catkin_ws/src/robot_navigation/dwb_plugins/include/dwb_plugins/standard_traj_generator.h:40,
                 from /home/nlimpert/dev/catkin_ws/src/robot_navigation/dwb_plugins/include/dwb_plugins/limited_accel_generator.h:38,
                 from /home/nlimpert/dev/catkin_ws/src/robot_navigation/dwb_plugins/src/limited_accel_generator.cpp:35:
/home/nlimpert/dev/catkin_ws/devel_isolated/dwb_plugins/include/dwb_plugins/KinematicParamsConfig.h:64:9: error: unnecessary parentheses in declaration of ‘field’ [-Werror=parentheses]
       T (KinematicParamsConfig::* field);
         ^
/home/nlimpert/dev/catkin_ws/devel_isolated/dwb_plugins/include/dwb_plugins/KinematicParamsConfig.h:209:9: error: unnecessary parentheses in declaration of ‘field’ [-Werror=parentheses]
       T (PT::* field);
         ^
cc1plus: all warnings being treated as errors
make[2]: *** [CMakeFiles/standard_traj_generator.dir/build.make:76: CMakeFiles/standard_traj_generator.dir/src/limited_accel_generator.cpp.o] Error 1
In file included from /home/nlimpert/dev/catkin_ws/src/robot_navigation/dwb_plugins/include/dwb_plugins/kinematic_parameters.h:40,
                 from /home/nlimpert/dev/catkin_ws/src/robot_navigation/dwb_plugins/include/dwb_plugins/velocity_iterator.h:40,
                 from /home/nlimpert/dev/catkin_ws/src/robot_navigation/dwb_plugins/include/dwb_plugins/standard_traj_generator.h:40,
                 from /home/nlimpert/dev/catkin_ws/src/robot_navigation/dwb_plugins/src/standard_traj_generator.cpp:35:
/home/nlimpert/dev/catkin_ws/devel_isolated/dwb_plugins/include/dwb_plugins/KinematicParamsConfig.h:64:9: error: unnecessary parentheses in declaration of ‘field’ [-Werror=parentheses]
       T (KinematicParamsConfig::* field);
         ^
/home/nlimpert/dev/catkin_ws/devel_isolated/dwb_plugins/include/dwb_plugins/KinematicParamsConfig.h:209:9: error: unnecessary parentheses in declaration of ‘field’ [-Werror=parentheses]
       T (PT::* field);
         ^
```