### PR TITLE
[Windows][melodic] Fix _CUSTOM_PYTHONPATH_ENV on Windows build

### DIFF
--- a/cmake/dynamic_reconfigure-macros.cmake
+++ b/cmake/dynamic_reconfigure-macros.cmake
@@ -46,6 +46,12 @@ macro(generate_dynamic_reconfigure_options)
         )
         set("_CUSTOM_PYTHONPATH_ENV" "${CMAKE_CURRENT_BINARY_DIR}/setup_custom_pythonpath.sh")
       endif()
+    elseif(WIN32)
+      # Package could have no ${CATKIN_GLOBAL_PYTHON_DESTINATION} if it doesn't call
+      # catkin_python_setup().
+      # However, since Windows doesn't support shebang, we still need python to be added
+      # into the _cmd later.
+      set("_CUSTOM_PYTHONPATH_ENV" "${PYTHON_EXECUTABLE}")
     endif()
 
     assert(CATKIN_ENV)


### PR DESCRIPTION
On Windows, even if the project calling `generate_dynamic_reconfigure_options()` doesn't have `${CATKIN_GLOBAL_PYTHON_DESTINATION}`, it still needs to set `_CUSTOM_PYTHONPATH_ENV` to something like `python`, because Windows doesn't have shebang support and cannot run the `<generated>.cfg` directly.

(This change is verified in https://aka.ms/ros project.)