### PR TITLE
Revert "ConfigType.h.template: fixed warnings"

### DIFF
--- a/templates/ConfigType.h.template
+++ b/templates/ConfigType.h.template
@@ -44,7 +44,6 @@ namespace ${pkgname}
         description = d;
         edit_method = e;
       }
-      virtual ~AbstractParamDescription() = default;
 
       virtual void clamp(${configname}Config &config, const ${configname}Config &max, const ${configname}Config &min) const = 0;
       virtual void calcLevel(uint32_t &level, const ${configname}Config &config1, const ${configname}Config &config2) const = 0;
@@ -72,7 +71,7 @@ namespace ${pkgname}
 
       T ${configname}Config::* field;
 
-      virtual void clamp(${configname}Config &config, const ${configname}Config &max, const ${configname}Config &min) const override
+      virtual void clamp(${configname}Config &config, const ${configname}Config &max, const ${configname}Config &min) const
       {
         if (config.*field > max.*field)
           config.*field = max.*field;
@@ -81,33 +80,33 @@ namespace ${pkgname}
           config.*field = min.*field;
       }
 
-      virtual void calcLevel(uint32_t &comb_level, const ${configname}Config &config1, const ${configname}Config &config2) const override
+      virtual void calcLevel(uint32_t &comb_level, const ${configname}Config &config1, const ${configname}Config &config2) const
       {
         if (config1.*field != config2.*field)
           comb_level |= level;
       }
 
-      virtual void fromServer(const ros::NodeHandle &nh, ${configname}Config &config) const override
+      virtual void fromServer(const ros::NodeHandle &nh, ${configname}Config &config) const
       {
         nh.getParam(name, config.*field);
       }
 
-      virtual void toServer(const ros::NodeHandle &nh, const ${configname}Config &config) const override
+      virtual void toServer(const ros::NodeHandle &nh, const ${configname}Config &config) const
       {
         nh.setParam(name, config.*field);
       }
 
-      virtual bool fromMessage(const dynamic_reconfigure::Config &msg, ${configname}Config &config) const override
+      virtual bool fromMessage(const dynamic_reconfigure::Config &msg, ${configname}Config &config) const
       {
         return dynamic_reconfigure::ConfigTools::getParameter(msg, name, config.*field);
       }
 
-      virtual void toMessage(dynamic_reconfigure::Config &msg, const ${configname}Config &config) const override
+      virtual void toMessage(dynamic_reconfigure::Config &msg, const ${configname}Config &config) const
       {
         dynamic_reconfigure::ConfigTools::appendParameter(msg, name, config.*field);
       }
 
-      virtual void getValue(const ${configname}Config &config, boost::any &val) const override
+      virtual void getValue(const ${configname}Config &config, boost::any &val) const
       {
         val = config.*field;
       }
@@ -124,8 +123,6 @@ namespace ${pkgname}
         state = s;
         id = i;
       }
-
-      virtual ~AbstractGroupDescription() = default;
 
       std::vector<AbstractParamDescriptionConstPtr> abstract_parameters;
       bool state;
@@ -164,7 +161,7 @@ namespace ${pkgname}
         abstract_parameters = g.abstract_parameters;
       }
 
-      virtual bool fromMessage(const dynamic_reconfigure::Config &msg, boost::any &cfg) const override
+      virtual bool fromMessage(const dynamic_reconfigure::Config &msg, boost::any &cfg) const
       {
         PT* config = boost::any_cast<PT*>(cfg);
         if(!dynamic_reconfigure::ConfigTools::getGroupState(msg, name, (*config).*field))
@@ -180,7 +177,7 @@ namespace ${pkgname}
         return true;
       }
 
-      virtual void setInitialState(boost::any &cfg) const override
+      virtual void setInitialState(boost::any &cfg) const
       {
         PT* config = boost::any_cast<PT*>(cfg);
         T* group = &((*config).*field);
@@ -194,7 +191,7 @@ namespace ${pkgname}
 
       }
 
-      virtual void updateParams(boost::any &cfg, ${configname}Config &top) const override
+      virtual void updateParams(boost::any &cfg, ${configname}Config &top) const
       {
         PT* config = boost::any_cast<PT*>(cfg);
 
@@ -208,7 +205,7 @@ namespace ${pkgname}
         }
       }
 
-      virtual void toMessage(dynamic_reconfigure::Config &msg, const boost::any &cfg) const override
+      virtual void toMessage(dynamic_reconfigure::Config &msg, const boost::any &cfg) const
       {
         const PT config = boost::any_cast<PT>(cfg);
         dynamic_reconfigure::ConfigTools::appendGroup<T>(msg, name, id, parent, config.*field);


### PR DESCRIPTION
Reverts ros/dynamic_reconfigure#136

I realized after looking at this that it breaks ABI, and should be targeted to Noetic, sorry for the churn.