### PR TITLE
Change the substitution of spaces

### DIFF
--- a/src/dynamic_reconfigure/parameter_generator.py
+++ b/src/dynamic_reconfigure/parameter_generator.py
@@ -101,7 +101,7 @@ class ParameterGenerator:
         instances = {}
 
         def __init__(self, gen, name, type, state, id, parent):
-            self.name = name.replace(" ", "_")
+            self.name = name.replace(" ", "\_")
             self.type = type
             self.groups = []
             self.parameters = []

--- a/src/dynamic_reconfigure/parameter_generator_catkin.py
+++ b/src/dynamic_reconfigure/parameter_generator_catkin.py
@@ -102,7 +102,7 @@ class ParameterGenerator(object):
         instances = {}
 
         def __init__(self, gen, name, type, state, id, parent):
-            self.name = name.replace(" ", "_")
+            self.name = name.replace(" ", "\_")
             self.type = type
             self.groups = []
             self.parameters = []


### PR DESCRIPTION
Currently, spaces in group names get substituted to underscores. It is impossible to set spaces in the group names. 
Removing the whole replacement works for me, but maybe it is implemented for some edge case. So i added the escape sequence `\_` as seen in pull request ros-visualization/rqt_reconfigure/pull/63 in the rqt gui. It would be nice, if the replace gets removed or the spaces get replaced to the escape sequence.