### PR TITLE
Use PYTHON_EXECUTABLE to generate config headers.

### DIFF
--- a/cfg/Test.cfg
+++ b/cfg/Test.cfg
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 # Software License Agreement (BSD License)
 #
 # Copyright (c) 2009, Willow Garage, Inc.

--- a/cmake/dynamic_reconfigure-macros.cmake
+++ b/cmake/dynamic_reconfigure-macros.cmake
@@ -46,11 +46,9 @@ macro(generate_dynamic_reconfigure_options)
         )
         set("_CUSTOM_PYTHONPATH_ENV" "${CMAKE_CURRENT_BINARY_DIR}/setup_custom_pythonpath.sh")
       endif()
-    elseif(WIN32)
+    else()
       # Package could have no ${CATKIN_GLOBAL_PYTHON_DESTINATION} if it doesn't call
-      # catkin_python_setup().
-      # However, since Windows doesn't support shebang, we still need python to be added
-      # into the _cmd later.
+      # catkin_python_setup(), however we still need to use the correct Python.
       set("_CUSTOM_PYTHONPATH_ENV" "${PYTHON_EXECUTABLE}")
     endif()
 

--- a/cmake/setup_custom_pythonpath.bat.in
+++ b/cmake/setup_custom_pythonpath.bat.in
@@ -1,4 +1,4 @@
 REM generated from dynamic_reconfigure/cmake/setup_custom_pythonpath.bat.in
 
 set PYTHONPATH=@CATKIN_DEVEL_PREFIX@/@CATKIN_GLOBAL_PYTHON_DESTINATION@;%PYTHONPATH%
-call python %*
+call @PYTHON_EXECUTABLE@ %*

--- a/cmake/setup_custom_pythonpath.sh.in
+++ b/cmake/setup_custom_pythonpath.sh.in
@@ -2,4 +2,4 @@
 # generated from dynamic_reconfigure/cmake/setup_custom_pythonpath.sh.in
 
 PYTHONPATH=@CATKIN_DEVEL_PREFIX@/@CATKIN_GLOBAL_PYTHON_DESTINATION@:$PYTHONPATH
-exec "$@"
+exec @PYTHON_EXECUTABLE@ "$@"

--- a/package.xml
+++ b/package.xml
@@ -4,8 +4,8 @@
   <name>dynamic_reconfigure</name>
   <version>1.6.0</version>
   <description>
-    The dynamic_reconfigure package which provides a means to update
-    node parameters at runtime without having to restart the node.
+    The dynamic_reconfigure package provides a means to update parameters
+    at runtime without having to restart the node.
   </description>
   <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
   <license>BSD</license>

--- a/package.xml
+++ b/package.xml
@@ -4,8 +4,8 @@
   <name>dynamic_reconfigure</name>
   <version>1.6.0</version>
   <description>
-    This unary stack contains the dynamic_reconfigure package which provides a means to change
-    node parameters at any time without having to restart the node.
+    The dynamic_reconfigure package which provides a means to update
+    node parameters at runtime without having to restart the node.
   </description>
   <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
   <license>BSD</license>

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 


### PR DESCRIPTION
All current `.cfg` files in the wild are executable and have shebang lines. Unfortunately, because they are invoked at build time, this is another instance where the specific `python` that `usr/bin/env python` leads to becomes important, especially in an environment like Ubuntu Focal, where `python` is Python 2 (and may not even exist at all).

In this case, it's easy to address— call the correct interpreter directly in the wrapper generated by `configure_file`. The Windows version already does something similar, so I've updated it to also use the `PYTHON_EXECUTABLE` cmake var rather than just `python`.

See related discussions in https://github.com/ros/catkin/pull/1044, https://github.com/ros/ros_comm/issues/1830, https://github.com/ros/roslisp/pull/43

FYI @dirk-thomas 
