### PR TITLE
Bump CMake minimum version to use CMP0048

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0.2)
 project(dynamic_reconfigure)
 
 find_package(catkin REQUIRED COMPONENTS message_generation roscpp std_msgs)


### PR DESCRIPTION
Fixes the corresponding CMake warning.

See ros/catkin#1052

Signed-off-by: Michael Carroll <michael@openrobotics.org>