### PR TITLE
Revert #140

### DIFF
--- a/cmake/dynamic_reconfigure-macros.cmake
+++ b/cmake/dynamic_reconfigure-macros.cmake
@@ -113,7 +113,7 @@ macro(dynreconf_called)
 
     # make sure we can find generated messages and that they overlay all other includes
     # Use system to skip warnings from these includes
-    include_directories(BEFORE SYSTEM ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+    include_directories(BEFORE ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION})
     # pass the include directory to catkin_package()
     list(APPEND ${PROJECT_NAME}_INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION})
     # ensure that the folder exists


### PR DESCRIPTION
We discovered that there is an issue when building overlays with this in
place.  This didn't show up in the normal CI process where we don't
overlay.  The `SYSTEM` parameter causes gcc to use `-isystem`, which
does suppress warnings as the PR intended, but it also re-orders the
include paths, which can cause overlays to break.

Signed-off-by: Michael Carroll <michael@openrobotics.org>