### PR TITLE
[noetic] import setup from setuptools instead of distutils-core

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
Following the guidelines to migrate packages to [noetic](http://wiki.ros.org/noetic/Migration)

 - import setup from setuptools instead of distutils-core

Signed-off-by: ahcorde <ahcorde@gmail.com>