### PR TITLE
Make Config object pickle-able in Python 3

### DIFF
--- a/src/dynamic_reconfigure/encoding.py
+++ b/src/dynamic_reconfigure/encoding.py
@@ -49,7 +49,7 @@ class Config(dict):
         dict.__init__(self, *args, **kwargs)
 
     def __getstate__(self):
-        return self.__dict__.items()
+        return list(self.__dict__.items())
 
     def __setstate__(self, items):
         for key, val in items:


### PR DESCRIPTION
In Python 3, `.items()` returns a `dict_items` object, which can't easily be pickled. In Python 2, `.items()` returns a list of tuples, which can be pickled.

To maintain pickle-ability, convert the `dict_items` into a list.

`rqt_reconfigure` has a feature which saves current Dynamic Reconfigure configuration to a file, which is broken in Noetic without this change.