### PR TITLE
WIP: Python3 migration

### DIFF
--- a/cmake/gendeps
+++ b/cmake/gendeps
@@ -34,7 +34,7 @@
 #
 # Revision $Id$
 
-from __future__ import print_function
+
 
 import sys
 import inspect

--- a/scripts/dynparam
+++ b/scripts/dynparam
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 #
 # Software License Agreement (BSD License)
 #
@@ -33,7 +33,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 # Revision $Id$
-from __future__ import print_function
+
 
 NAME='dynparam'
 import roslib; roslib.load_manifest('dynamic_reconfigure')
@@ -156,7 +156,7 @@ def do_load():
         parser.error("too many arguments")
     node, path = args[0], args[1]
 
-    f = file(path, 'r')
+    f = open(path, 'r')
     try:
         params = {}
         for doc in yaml.load_all(f.read()):
@@ -184,7 +184,7 @@ def do_dump():
     connect()
     params = get_params(node, timeout=options.timeout)
     if params is not None:
-        f = file(path, 'w')
+        f = open(path, 'w')
         try:
             yaml.dump(params, f)
             return

--- a/scripts/reconfigure_gui
+++ b/scripts/reconfigure_gui
@@ -32,7 +32,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
-from __future__ import print_function
+
 
 if __name__ == '__main__':
     print('\033[91m' + "reconfigure_gui has moved!\n" + '\033[0m')

--- a/src/dynamic_reconfigure/__init__.py
+++ b/src/dynamic_reconfigure/__init__.py
@@ -65,4 +65,4 @@ def find_reconfigure_services():
 
 
 def get_parameter_names(descr):
-    return descr.defaults.keys()
+    return list(descr.defaults.keys())

--- a/src/dynamic_reconfigure/client.py
+++ b/src/dynamic_reconfigure/client.py
@@ -35,7 +35,7 @@ Python client API for dynamic_reconfigure (L{DynamicReconfigureClient}) as well 
 example server implementation (L{DynamicReconfigureServer}).
 """
 
-from __future__ import print_function, with_statement
+
 
 try:
     import roslib; roslib.load_manifest('dynamic_reconfigure')
@@ -203,8 +203,8 @@ class Client(object):
                                     found = True
                         if not found:
                             if sys.version_info.major < 3:
-                                if type(value) is unicode:
-                                    changes[name] = unicode(value)
+                                if type(value) is str:
+                                    changes[name] = str(value)
                                 else:
                                     changes[name] = dest_type(value)
                             else:
@@ -213,7 +213,7 @@ class Client(object):
                     except ValueError as e:
                         raise DynamicReconfigureParameterException('can\'t set parameter \'%s\' of %s: %s' % (name, str(dest_type), e))
 
-        if 'groups' in changes.keys():
+        if 'groups' in list(changes.keys()):
             changes['groups'] = self.update_groups(changes['groups'])
 
         config = encode_config(changes)
@@ -240,7 +240,7 @@ class Client(object):
         descr = self.get_group_descriptions()
 
         def update_state(group, description):
-            for p, g in description['groups'].items():
+            for p, g in list(description['groups'].items()):
                 if g['name'] == group:
                     description['groups'][p]['state'] = changes[group]
                 else:

--- a/src/dynamic_reconfigure/encoding.py
+++ b/src/dynamic_reconfigure/encoding.py
@@ -49,7 +49,7 @@ class Config(dict):
         dict.__init__(self, *args, **kwargs)
 
     def __getstate__(self):
-        return self.__dict__.items()
+        return list(self.__dict__.items())
 
     def __setstate__(self, items):
         for key, val in items:
@@ -75,7 +75,7 @@ class Config(dict):
 
     def __deepcopy__(self, memo):
         c = type(self)({})
-        for key, value in self.items():
+        for key, value in list(self.items()):
             c[copy.deepcopy(key)] = copy.deepcopy(value)
 
         return c
@@ -112,7 +112,7 @@ def encode_groups(parent, group):
 
 def encode_config(config, flat=True):
     msg = ConfigMsg()
-    for k, v in config.items():
+    for k, v in list(config.items()):
         ## @todo add more checks here?
         if type(v) == int:
             msg.ints.append(IntParameter(k, v))
@@ -120,7 +120,7 @@ def encode_config(config, flat=True):
             msg.bools.append(BoolParameter(k, v))
         elif type(v) == str:
             msg.strs.append(StrParameter(k, v))
-        elif sys.version_info.major < 3 and isinstance(v, unicode):
+        elif sys.version_info.major < 3 and isinstance(v, str):
             msg.strs.append(StrParameter(k, v))
         elif type(v) == float:
             msg.doubles.append(DoubleParameter(k, v))
@@ -128,7 +128,7 @@ def encode_config(config, flat=True):
             if flat is True:
                 def flatten(g):
                     groups = []
-                    for _name, group in g['groups'].items():
+                    for _name, group in list(g['groups'].items()):
                         groups.extend(flatten(group))
                         groups.append(GroupState(group['name'], group['state'], group['id'], group['parent']))
                     return groups
@@ -277,7 +277,7 @@ def initial_config(msg, description=None):
         def add_params(group, descr):
             for param in descr['parameters']:
                 group['parameters'][param['name']] = d[param['name']]
-            for _n, g in group['groups'].items():
+            for _n, g in list(group['groups'].items()):
                 for dr in descr['groups']:
                     if dr['name'] == g['name']:
                         add_params(g, dr)
@@ -290,7 +290,7 @@ def initial_config(msg, description=None):
 def decode_config(msg, description=None):
     if sys.version_info.major < 3:
         for s in msg.strs:
-            if not isinstance(s.value, unicode):
+            if not isinstance(s.value, str):
                 try:
                     s.value.decode('ascii')
                 except UnicodeDecodeError:
@@ -302,10 +302,10 @@ def decode_config(msg, description=None):
 
         def add_params(group, descr):
             for param in descr['parameters']:
-                if param['name'] in d.keys():
+                if param['name'] in list(d.keys()):
                     group[param['name']] = d[param['name']]
-            for _n, g in group['groups'].items():
-                for _nr, dr in descr['groups'].items():
+            for _n, g in list(group['groups'].items()):
+                for _nr, dr in list(descr['groups'].items()):
                     if dr['name'] == g['name']:
                         add_params(g, dr)
 
@@ -318,7 +318,7 @@ def extract_params(group):
     params = []
     params.extend(group['parameters'])
     try:
-        for _n, g in group['groups'].items():
+        for _n, g in list(group['groups'].items()):
             params.extend(extract_params(g))
     except AttributeError:
         for g in group['groups']:

--- a/src/dynamic_reconfigure/parameter_generator.py
+++ b/src/dynamic_reconfigure/parameter_generator.py
@@ -39,7 +39,7 @@
 ## @todo
 # Need to check types of min max and default
 # Need to put sane error on exceptions
-from __future__ import print_function
+
 
 import roslib; roslib.load_manifest("dynamic_reconfigure")
 import roslib.packages

--- a/src/dynamic_reconfigure/parameter_generator_catkin.py
+++ b/src/dynamic_reconfigure/parameter_generator_catkin.py
@@ -42,7 +42,7 @@
 # Need to check types of min max and default
 # Need to put sane error on exceptions
 
-from __future__ import print_function
+
 
 import inspect
 import os
@@ -560,7 +560,7 @@ class ParameterGenerator(object):
 
     def _rreplace_str_with_val_in_dict(self, orig_dict, old_str, new_val):
         # Recursively replace any match of old_str by new_val in a dictionary
-        for k, v in orig_dict.items():
+        for k, v in list(orig_dict.items()):
             if isinstance(v, dict):
                 self._rreplace_str_with_val_in_dict(v, old_str, new_val)
             elif isinstance(v, list):

--- a/src/dynamic_reconfigure/server.py
+++ b/src/dynamic_reconfigure/server.py
@@ -35,7 +35,7 @@ Python client API for dynamic_reconfigure (L{DynamicReconfigureClient}) as well 
 example server implementation (L{DynamicReconfigureServer}).
 """
 
-from __future__ import with_statement
+
 
 try:
     import roslib; roslib.load_manifest('dynamic_reconfigure')

--- a/test/simple_python_client_test.py
+++ b/test/simple_python_client_test.py
@@ -81,7 +81,7 @@ class TestSimpleDynamicReconfigureClient(unittest.TestCase):
         self.assertEqual('bar', config['mstr_'])
 
         # Kanji for konnichi wa (hello)
-        str_ = u"今日は"
+        str_ = "今日は"
 
         client.update_configuration(
             {"mstr_": str_}
@@ -91,12 +91,12 @@ class TestSimpleDynamicReconfigureClient(unittest.TestCase):
 
         config = client.get_configuration(timeout=5)
 
-        self.assertEqual(u"今日は", config['mstr_'])
-        self.assertEqual(type(u"今日は"), type(config['mstr_']))
-        self.assertEqual(u"今日は", rospy.get_param('/ref_server/mstr_'))
+        self.assertEqual("今日は", config['mstr_'])
+        self.assertEqual(type("今日は"), type(config['mstr_']))
+        self.assertEqual("今日は", rospy.get_param('/ref_server/mstr_'))
 
         # Hiragana for konnichi wa (hello)
-        str_ = u"こんにちは"
+        str_ = "こんにちは"
 
         client.update_configuration(
             {"mstr_": str_}
@@ -106,9 +106,9 @@ class TestSimpleDynamicReconfigureClient(unittest.TestCase):
 
         config = client.get_configuration(timeout=5)
 
-        self.assertEqual(u"こんにちは", config['mstr_'])
-        self.assertEqual(type(u"こんにちは"), type(config['mstr_']))
-        self.assertEqual(u"こんにちは", rospy.get_param('/ref_server/mstr_'))
+        self.assertEqual("こんにちは", config['mstr_'])
+        self.assertEqual(type("こんにちは"), type(config['mstr_']))
+        self.assertEqual("こんにちは", rospy.get_param('/ref_server/mstr_'))
 
 
 if __name__ == "__main__":

--- a/test/testclient.py
+++ b/test/testclient.py
@@ -30,7 +30,7 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from __future__ import print_function
+
 
 import roslib; roslib.load_manifest('dynamic_reconfigure')
 import rospy
@@ -54,8 +54,8 @@ import time
 
 
 def print_config(config):
-    for k, v in config.items():
-        print(k, ":", v)
+    for k, v in list(config.items()):
+        print((k, ":", v))
     print('')
 
 
@@ -105,7 +105,7 @@ time.sleep(1)
 
 # You can access constants defined in Test.cfg file in the following way:
 import dynamic_reconfigure.cfg.TestConfig as Config
-print("Medium is a constant that is set to 1:", Config.Test_Medium)
+print(("Medium is a constant that is set to 1:", Config.Test_Medium))
 
 # This is useful for setting enums:
 print("Configuration after setting int_enum_ to Medium:")

--- a/test/testserver.py
+++ b/test/testserver.py
@@ -32,7 +32,7 @@
 #  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 #  POSSIBILITY OF SUCH DAMAGE.
 #********************************************************************/
-from __future__ import print_function
+
 
 import roslib; roslib.load_manifest('dynamic_reconfigure')
 import rospy

--- a/test/testserver_multiple_ns.py
+++ b/test/testserver_multiple_ns.py
@@ -32,7 +32,7 @@
 #  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 #  POSSIBILITY OF SUCH DAMAGE.
 #********************************************************************/
-from __future__ import print_function
+
 
 import roslib; roslib.load_manifest('dynamic_reconfigure')
 import rospy


### PR DESCRIPTION
I'm migrating a codebase to python3 and noticed dynamic_reconfigure still used python2, making my control pipeline go bonkers. Right now I don't have the time to do extensive testing, this is basically just running `2to3` and `s/file(/open(`, but my control pipeline now works. Any review is welcome :)