### PR TITLE
[noetic] Explicit to use sys.exit

### DIFF
--- a/cfg/Test.cfg
+++ b/cfg/Test.cfg
@@ -33,6 +33,8 @@
 
 PACKAGE='dynamic_reconfigure_test'
 
+import sys
+
 from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
@@ -73,4 +75,4 @@ group3.add("deep_var_double", double_t, 0, "Were super far down now!!", -1.0)
 group12 = gen.add_group("Upper Group 2")
 group12.add("some_param", int_t, 0, "Some param", 20)
 
-exit(gen.generate(PACKAGE, "test_reconfigure_server_cpp", "Test"))
+sys.exit(gen.generate(PACKAGE, "test_reconfigure_server_cpp", "Test"))


### PR DESCRIPTION
According to [this](https://docs.python.org/3.8/library/constants.html#exit), the `exit` idiom doesn't always exist in a Python environment. For example, if the [embeddable package](https://docs.python.org/3/using/windows.html#the-embeddable-package) is in use as the runtime, the `site` module won't be loaded by default and `exit` won't be available in this setting.

This patch is to use `sys.exit` which is built-in in the `sys` module.