### PR TITLE
narrow down required boost dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0.2)
 project(dynamic_reconfigure)
 
 find_package(catkin REQUIRED COMPONENTS message_generation roscpp std_msgs)
-find_package(Boost REQUIRED COMPONENTS system thread chrono)
+find_package(Boost REQUIRED)
 
 include_directories(include)
 include_directories(SYSTEM ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})

--- a/package.xml
+++ b/package.xml
@@ -26,7 +26,10 @@
   <build_depend>roscpp_serialization</build_depend>
   <build_depend>rostest</build_depend>
 
-  <depend>boost</depend>
+  <build_export_depend>libboost-chrono-dev</build_export_depend>
+  <build_export_depend>libboost-thread-dev</build_export_depend>
+
+  <depend>libboost-dev</depend>
   <depend>roscpp</depend>
   <depend>std_msgs</depend>
 


### PR DESCRIPTION
In an [ongoing effort](https://discourse.ros.org/t/generating-dev-and-runtime-artefacts-from-ros-packages/12448) to reduce the footprint on the target systems, it is preferred to declare specific dependencies instead of generic ones.