### PR TITLE
Remove obsolete load_manifest

### DIFF
--- a/scripts/dynparam
+++ b/scripts/dynparam
@@ -36,7 +36,6 @@
 from __future__ import print_function
 
 NAME='dynparam'
-import roslib; roslib.load_manifest('dynamic_reconfigure')
 import rospy
 import optparse
 import sys

--- a/src/dynamic_reconfigure/client.py
+++ b/src/dynamic_reconfigure/client.py
@@ -37,10 +37,6 @@ example server implementation (L{DynamicReconfigureServer}).
 
 from __future__ import print_function, with_statement
 
-try:
-    import roslib; roslib.load_manifest('dynamic_reconfigure')
-except Exception:
-    pass
 import rospy
 import sys
 import threading

--- a/src/dynamic_reconfigure/encoding.py
+++ b/src/dynamic_reconfigure/encoding.py
@@ -30,10 +30,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-try:
-    import roslib; roslib.load_manifest('dynamic_reconfigure')
-except Exception:
-    pass
 import copy
 import sys
 

--- a/src/dynamic_reconfigure/parameter_generator.py
+++ b/src/dynamic_reconfigure/parameter_generator.py
@@ -41,7 +41,6 @@
 # Need to put sane error on exceptions
 from __future__ import print_function
 
-import roslib; roslib.load_manifest("dynamic_reconfigure")
 import roslib.packages
 from string import Template
 import os

--- a/src/dynamic_reconfigure/server.py
+++ b/src/dynamic_reconfigure/server.py
@@ -37,10 +37,6 @@ example server implementation (L{DynamicReconfigureServer}).
 
 from __future__ import with_statement
 
-try:
-    import roslib; roslib.load_manifest('dynamic_reconfigure')
-except Exception:
-    pass
 import rospy
 import threading
 import copy

--- a/test/testclient.py
+++ b/test/testclient.py
@@ -32,7 +32,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 from __future__ import print_function
 
-import roslib; roslib.load_manifest('dynamic_reconfigure')
 import rospy
 from dynamic_reconfigure.client import Client as DynamicReconfigureClient
 import time

--- a/test/testserver.py
+++ b/test/testserver.py
@@ -34,7 +34,6 @@
 #********************************************************************/
 from __future__ import print_function
 
-import roslib; roslib.load_manifest('dynamic_reconfigure')
 import rospy
 import dynamic_reconfigure.server
 from dynamic_reconfigure.cfg import TestConfig

--- a/test/testserver_multiple_ns.py
+++ b/test/testserver_multiple_ns.py
@@ -34,7 +34,6 @@
 #********************************************************************/
 from __future__ import print_function
 
-import roslib; roslib.load_manifest('dynamic_reconfigure')
 import rospy
 import dynamic_reconfigure.server
 from dynamic_reconfigure.cfg import TestConfig


### PR DESCRIPTION
I've been doing some profiling on node startup time, and have noticed that loading the manifest is one of the time consuming steps, taking about 0.4-0.5 seconds when a node uses dynamic reconfigure.

A tiny python script to show this:

```
import cProfile
pr = cProfile.Profile()
pr.enable()

import dynamic_reconfigure.client

pr.disable()
pr.dump_stats("dynamic_reconfigure.stats")
```

After running the file the stats can be viewed with `snakeviz`. Below is the resulting visualisation:

![Screenshot_2020-11-04 dynamic_reconfigure](https://user-images.githubusercontent.com/636456/98100763-385e7780-1e89-11eb-92cb-46fbef5d4c0f.png)


I believe that loading the manifest is no longer necessary for catkin packages. I saw this same time consumption in the tf2_ros package, and in recent versions (0.6.6), the manifest loading has been removed as per https://github.com/ros/geometry2/pull/404.

These same changes can probably be added to the noetic branch as well.