### PR TITLE
Fix flaky multipleClients test

### DIFF
--- a/test/test_client.cpp
+++ b/test/test_client.cpp
@@ -121,16 +121,20 @@ TEST(dynamic_reconfigure_simple_client, setGetConfig) {
 }
 
 TEST(dynamic_reconfigure_simple_client, multipleClients) {
-  Client<TestConfig> client1("/ref_server", &configurationCallback);
-  Client<TestConfig> client2("/ref_server", &configurationCallback);
-  Client<TestConfig> client3("/ref_server", &configurationCallback);
-  client3.setConfiguration(TestConfig::__getDefault__());
+  Client<TestConfig> client1("/ref_server", &configurationCallback,
+                             &descriptionCallback);
+  Client<TestConfig> client2("/ref_server", &configurationCallback,
+                             &descriptionCallback);
+  Client<TestConfig> client3("/ref_server", &configurationCallback,
+                             &descriptionCallback);
+  ros::Duration(0.2).sleep();
+  EXPECT_TRUE(client3.setConfiguration(TestConfig::__getDefault__()));
   ros::Duration(0.2).sleep();
   EXPECT_EQ(0, CONFIG.int_);
-  client1.setConfiguration(TestConfig::__getMin__());
+  EXPECT_TRUE(client1.setConfiguration(TestConfig::__getMin__()));
   ros::Duration(0.2).sleep();
   EXPECT_EQ(-10, CONFIG.int_);
-  client2.setConfiguration(TestConfig::__getMax__());
+  EXPECT_TRUE(client2.setConfiguration(TestConfig::__getMax__()));
   ros::Duration(0.2).sleep();
   EXPECT_EQ(10, CONFIG.int_);
 }


### PR DESCRIPTION
Sleep is required especially on many-core environment.