### PR TITLE
set ns as '~' when namespace is '~'

### DIFF
--- a/src/dynamic_reconfigure/server.py
+++ b/src/dynamic_reconfigure/server.py
@@ -55,7 +55,7 @@ from dynamic_reconfigure.srv import Reconfigure as ReconfigureSrv
 class Server(object):
     def __init__(self, type, callback, namespace=""):
         self.mutex = threading.Lock()
-        if not namespace:
+        if not namespace or namespace == "~":
             self.ns = "~"
         else:
             if namespace[0] not in ["/", "~"]:


### PR DESCRIPTION
when we pass `namespace='~'` in `dynamic_reconfigure.Server`, `self.ns` is set as `~/`.
`dynamic_reconfigure.Server` makes `/set_parameters` service with `self.ns = ~/`, which causes the issue below in `rqt_reconfigure`.
https://github.com/ros-visualization/rqt_reconfigure/issues/92

`self.ns` should be `~` when `namespace='~'` or `namespace=''`, so I made this PR.
I'm not super confident in this PR, so I want to do discussion about this feature.

Signed-off-by: Michael Carroll <michael@openrobotics.org>