### PR TITLE
Update client.py

### DIFF
--- a/src/dynamic_reconfigure/client.py
+++ b/src/dynamic_reconfigure/client.py
@@ -76,6 +76,7 @@ class Client(object):
         self.group_description = None
 
         self._param_types = None
+        self._param_types_initialized = False
 
         self._cv = threading.Condition()
 
@@ -128,14 +129,14 @@ class Client(object):
         """
         if timeout is None or timeout == 0.0:
             with self._cv:
-                while self.param_description is None:
+                while self._param_types_initialized is False:
                     if rospy.is_shutdown():
                         return None
                     self._cv.wait()
         else:
             start_time = time.time()
             with self._cv:
-                while self.param_description is None:
+                while self._param_types_initialized is False:
                     if rospy.is_shutdown():
                         return None
                     secs_left = timeout - (time.time() - start_time)
@@ -337,6 +338,7 @@ class Client(object):
             if n is not None and t is not None:
                 self._param_types[n] = self._param_type_from_string(t)
 
+        self._param_types_initialized = True
         with self._cv:
             self._cv.notifyAll()
         if self._description_callback is not None:


### PR DESCRIPTION
When using rqt_reconfigure with node with a lot of parameters, it seems some parameters are most of time not found when trying to update the configuration.
The parameters are listed in rqt_dynamic_reconfigure, but when trying to change value of some parameters "update_configuration" raises the exception line 185:
```bash
error updating parameters: don't know parameter xxx
``` 
When equivalent commands set and get succeed each time:
```bash
rosrun dynparam get <node_name> <param> 
rosrun dynparam set <node_name> <param> <value>
```
Not sure of what exactly happen as it is not fully repeatable, but the solution proposed in issue #163 seems to do the job.