### PR TITLE
Fix how generated headers are added to the include search path

### DIFF
--- a/cmake/dynamic_reconfigure-macros.cmake
+++ b/cmake/dynamic_reconfigure-macros.cmake
@@ -113,7 +113,7 @@ macro(dynreconf_called)
 
     # make sure we can find generated messages and that they overlay all other includes
     # Use system to skip warnings from these includes
-    include_directories(SYSTEM BEFORE ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+    include_directories(BEFORE SYSTEM ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION})
     # pass the include directory to catkin_package()
     list(APPEND ${PROJECT_NAME}_INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION})
     # ensure that the folder exists


### PR DESCRIPTION
The `include_directories` command is used incorrectly. The `BEFORE` has to go before the `SYSTEM`: https://cmake.org/cmake/help/latest/command/include_directories.html.

With the current implementation, the the actual directory and a non-existing directory `BEFORE` are instead added to the end.
