### PR TITLE
Add virtual destructor to ConfigType.h template

### DIFF
--- a/templates/ConfigType.h.template
+++ b/templates/ConfigType.h.template
@@ -44,6 +44,8 @@ namespace ${pkgname}
         description = d;
         edit_method = e;
       }
+      
+      virtual ~AbstractParamDescription() = default;
 
       virtual void clamp(${configname}Config &config, const ${configname}Config &max, const ${configname}Config &min) const = 0;
       virtual void calcLevel(uint32_t &level, const ${configname}Config &config1, const ${configname}Config &config2) const = 0;


### PR DESCRIPTION
There is no virtual destructor in this template. I see that it's already added to the noetic-devel branch, but not here. I don't see any reason why this shouldn't be here.