### PR TITLE
Add Loader=yaml.Loader to yaml.load

### DIFF
--- a/scripts/dynparam
+++ b/scripts/dynparam
@@ -110,7 +110,7 @@ Examples:
     node = args[0]
     if len(args) == 2:
         node, value = args[0], args[1]
-        values_dict = yaml.load(value)
+        values_dict = yaml.load(value, Loader=yaml.Loader)
         if type(values_dict) != dict:
             parser.error('invalid arguments. Please specify either a node name, parameter name and parameter value, or a node name and a YAML dictionary')
     elif len(args) == 3:
@@ -159,7 +159,7 @@ def do_load():
     f = open(path, 'r')
     try:
         params = {}
-        for doc in yaml.load_all(f.read()):
+        for doc in yaml.load_all(f.read(), Loader=yaml.Loader):
             params.update(doc)
     finally:
         f.close()


### PR DESCRIPTION
To enable proper behavior on the most recent versions of PyYaml, add `Loader=yaml.Loader` to the `yaml.load` and `yaml.load_all` calls. More information can be found here: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation.