### PR TITLE
Parameter conditionally enabled

### DIFF
--- a/msg/ParamDescription.msg
+++ b/msg/ParamDescription.msg
@@ -3,3 +3,4 @@ string type
 uint32 level
 string description
 string edit_method
+string enable_if

--- a/src/dynamic_reconfigure/encoding.py
+++ b/src/dynamic_reconfigure/encoding.py
@@ -101,7 +101,7 @@ def encode_groups(parent, group):
     msg.type = group['type']
 
     for param in group['parameters']:
-        msg.parameters.append(ParamDescription(param['name'], param['type'], param['level'], param['description'], param['edit_method']))
+        msg.parameters.append(ParamDescription(param['name'], param['type'], param['level'], param['description'], param['edit_method'], param['enable_if']))
 
     group_list.append(msg)
     for next in group['groups']:
@@ -180,6 +180,7 @@ def decode_description(msg):
                 'level': param.level,
                 'description': param.description,
                 'edit_method': param.edit_method,
+                'enable_if': param.enable_if,
             })
         return params
 

--- a/src/dynamic_reconfigure/parameter_generator.py
+++ b/src/dynamic_reconfigure/parameter_generator.py
@@ -125,7 +125,7 @@ class ParameterGenerator:
             self.groups.append(group)
             return group
 
-        def add(self, name, paramtype, level, description, default=None, min=None, max=None, edit_method=""):
+        def add(self, name, paramtype, level, description, default=None, min=None, max=None, edit_method="", enable_if=""):
             newparam = {
                 'name': name,
                 'type': paramtype,
@@ -137,6 +137,7 @@ class ParameterGenerator:
                 'srcline': inspect.currentframe().f_back.f_lineno,
                 'srcfile': inspect.getsourcefile(inspect.currentframe().f_back.f_code),
                 'edit_method': edit_method,
+                'enable_if': enable_if,
             }
             if type == str_t and (max is not None or min is not None):
                 raise Exception("Max or min specified for %s, which is of string type" % name)
@@ -270,8 +271,8 @@ class ParameterGenerator:
         return repr({'enum': constants, 'enum_description': description})
 
     # Wrap add and add_group for the default group
-    def add(self, name, paramtype, level, description, default=None, min=None, max=None, edit_method=""):
-        self.group.add(name, paramtype, level, description, default, min, max, edit_method)
+    def add(self, name, paramtype, level, description, default=None, min=None, max=None, edit_method="", enable_if=""):
+        self.group.add(name, paramtype, level, description, default, min, max, edit_method, enable_if)
 
     def add_group(self, name, type="", state=True):
         return self.group.add_group(name, type=type, state=state)
@@ -502,11 +503,11 @@ class ParameterGenerator:
                     paramdescr,
                     group.to_dict()['name'] +
                     ".abstract_parameters.push_back(${configname}Config::AbstractParamDescriptionConstPtr(new ${configname}Config::ParamDescription<${ctype}>(\"${name}\", \"${type}\", ${level}, "
-                    "\"${description}\", \"${edit_method}\", &${configname}Config::${name})));", param)
+                    "\"${description}\", \"${edit_method}\", \"${enable_if}\", &${configname}Config::${name})));", param)
                 self.appendline(
                     paramdescr,
                     "__param_descriptions__.push_back(${configname}Config::AbstractParamDescriptionConstPtr(new ${configname}Config::ParamDescription<${ctype}>(\"${name}\", \"${type}\", ${level}, "
-                    "\"${description}\", \"${edit_method}\", &${configname}Config::${name})));", param)
+                    "\"${description}\", \"${edit_method}\", \"${enable_if}\", &${configname}Config::${name})));", param)
 
             for g in group.groups:
                 write_params(g)

--- a/src/dynamic_reconfigure/parameter_generator_catkin.py
+++ b/src/dynamic_reconfigure/parameter_generator_catkin.py
@@ -126,7 +126,7 @@ class ParameterGenerator(object):
             self.groups.append(group)
             return group
 
-        def add(self, name, paramtype, level, description, default=None, min=None, max=None, edit_method=""):
+        def add(self, name, paramtype, level, description, default=None, min=None, max=None, edit_method="", enable_if=""):
             newparam = {
                 'name': name,
                 'type': paramtype,
@@ -138,6 +138,7 @@ class ParameterGenerator(object):
                 'srcline': inspect.currentframe().f_back.f_lineno,
                 'srcfile': inspect.getsourcefile(inspect.currentframe().f_back.f_code),
                 'edit_method': edit_method,
+                'enable_if': enable_if,
             }
             if (paramtype == str_t or paramtype == bool_t) and (max is not None or min is not None):
                 raise Exception(
@@ -287,8 +288,8 @@ class ParameterGenerator(object):
         return repr({'enum': constants, 'enum_description': description})
 
     # Wrap add and add_group for the default group
-    def add(self, name, paramtype, level, description, default=None, min=None, max=None, edit_method=""):
-        self.group.add(name, paramtype, level, description, default, min, max, edit_method)
+    def add(self, name, paramtype, level, description, default=None, min=None, max=None, edit_method="", enable_if=""):
+        self.group.add(name, paramtype, level, description, default, min, max, edit_method, enable_if)
 
     def add_group(self, name, type="", state=True):
         return self.group.add_group(name, type=type, state=state)
@@ -481,11 +482,11 @@ class ParameterGenerator(object):
                     paramdescr,
                     group.to_dict()['name'] +
                     ".abstract_parameters.push_back(${configname}Config::AbstractParamDescriptionConstPtr(new ${configname}Config::ParamDescription<${ctype}>(\"${name}\", \"${type}\", ${level}, "
-                    "\"${description}\", \"${edit_method}\", &${configname}Config::${name})));", param)
+                    "\"${description}\", \"${edit_method}\", \"${enable_if}\", &${configname}Config::${name})));", param)
                 self.appendline(
                     paramdescr,
                     "__param_descriptions__.push_back(${configname}Config::AbstractParamDescriptionConstPtr(new ${configname}Config::ParamDescription<${ctype}>(\"${name}\", \"${type}\", ${level}, "
-                    "\"${description}\", \"${edit_method}\", &${configname}Config::${name})));", param)
+                    "\"${description}\", \"${edit_method}\", \"${enable_if}\", &${configname}Config::${name})));", param)
 
             for g in group.groups:
                 write_params(g)

--- a/templates/ConfigType.h.template
+++ b/templates/ConfigType.h.template
@@ -36,13 +36,14 @@ namespace ${pkgname}
     {
     public:
       AbstractParamDescription(std::string n, std::string t, uint32_t l,
-          std::string d, std::string e)
+          std::string d, std::string e, std::string ei)
       {
         name = n;
         type = t;
         level = l;
         description = d;
         edit_method = e;
+        enable_if = ei;
       }
 
       virtual void clamp(${configname}Config &config, const ${configname}Config &max, const ${configname}Config &min) const = 0;
@@ -64,8 +65,8 @@ namespace ${pkgname}
     {
     public:
       ParamDescription(std::string a_name, std::string a_type, uint32_t a_level,
-          std::string a_description, std::string a_edit_method, T ${configname}Config::* a_f) :
-        AbstractParamDescription(a_name, a_type, a_level, a_description, a_edit_method),
+          std::string a_description, std::string a_edit_method, std::string a_enable_if, T ${configname}Config::* a_f) :
+        AbstractParamDescription(a_name, a_type, a_level, a_description, a_edit_method, a_enable_if),
         field(a_f)
       {}
 


### PR DESCRIPTION
Allows config files to specify that the user interface (RQT) should make the control enabled conditional on the value of another parameter.