### PR TITLE
fix: Race condition on quickly setting and getting config (#188)

### DIFF
--- a/include/dynamic_reconfigure/client.h
+++ b/include/dynamic_reconfigure/client.h
@@ -156,6 +156,8 @@ class Client {
     configuration.__toMessage__(srv.request.config);
     if (set_service_.call(srv)) {
       configuration.__fromMessage__(srv.response.config);
+      latest_configuration_.__fromMessage__(srv.response.config);
+      received_configuration_ = true;
       return true;
     } else {
       ROS_WARN("Could not set configuration");

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,9 @@
+add_rostest_gtest(dynamic_reconfigure-test_client_single_threaded test_cpp_client_single_threaded.test test_client_single_threaded.cpp)
+add_dependencies(dynamic_reconfigure-test_client_single_threaded ${PROJECT_NAME}_gencfg ${PROJECT_NAME}_generate_messages_cpp)
+target_link_libraries(dynamic_reconfigure-test_client_single_threaded dynamic_reconfigure_config_init_mutex ${catkin_LIBRARIES})
+
+add_dependencies(tests dynamic_reconfigure-test_client_single_threaded)
+
 add_executable(dynamic_reconfigure-ref_server EXCLUDE_FROM_ALL ref_server.cpp)
 add_dependencies(dynamic_reconfigure-ref_server ${PROJECT_NAME}_gencfg ${PROJECT_NAME}_generate_messages_cpp ${PROJECT_NAME}_generate_messages_py)
 target_link_libraries(dynamic_reconfigure-ref_server dynamic_reconfigure_config_init_mutex ${catkin_LIBRARIES})

--- a/test/test_client_single_threaded.cpp
+++ b/test/test_client_single_threaded.cpp
@@ -1,0 +1,24 @@
+#include <ros/ros.h>
+#include <gtest/gtest.h>
+#include <dynamic_reconfigure/client.h>
+#include <dynamic_reconfigure/TestConfig.h>
+
+using namespace dynamic_reconfigure_test;
+using namespace dynamic_reconfigure;
+
+
+TestConfig CONFIG;
+
+TEST(dynamic_reconfigure_client_single_thread, singleThreadedSetGet) {
+  Client<TestConfig> client("/ref_server");
+  CONFIG = TestConfig::__getDefault__();
+  EXPECT_TRUE(client.setConfiguration(CONFIG));
+  EXPECT_TRUE(client.getCurrentConfiguration(CONFIG));
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "dynamic_reconfigure_single_threaded_client_test");
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_cpp_client_single_threaded.test
+++ b/test/test_cpp_client_single_threaded.test
@@ -1,0 +1,5 @@
+<launch>
+  <node pkg="dynamic_reconfigure" type="dynamic_reconfigure-ref_server" name="ref_server" output="screen" />
+
+  <test test-name="dynamic_reconfigure_single_threaded_client_test" pkg="dynamic_reconfigure" type="dynamic_reconfigure-test_client_single_threaded" time-limit="1.0"/>
+</launch>


### PR DESCRIPTION
* fix: Race condition on quickly setting and getting config

fixes #187 by using the server's response to the set service to
update the latest configuration.

* test: add test for single threaded set and get using c++ client