### PR TITLE
Changed variable to size_t for consistency

### DIFF
--- a/templates/ConfigType.h.template
+++ b/templates/ConfigType.h.template
@@ -253,16 +253,16 @@ ${doline} ${linenum} "${filename}"
       {
         ROS_ERROR("${configname}Config::__fromMessage__ called with an unexpected parameter.");
         ROS_ERROR("Booleans:");
-        for (unsigned int i = 0; i < msg.bools.size(); i++)
+        for (size_t i = 0; i < msg.bools.size(); i++)
           ROS_ERROR("  %s", msg.bools[i].name.c_str());
         ROS_ERROR("Integers:");
-        for (unsigned int i = 0; i < msg.ints.size(); i++)
+        for (size_t i = 0; i < msg.ints.size(); i++)
           ROS_ERROR("  %s", msg.ints[i].name.c_str());
         ROS_ERROR("Doubles:");
-        for (unsigned int i = 0; i < msg.doubles.size(); i++)
+        for (size_t i = 0; i < msg.doubles.size(); i++)
           ROS_ERROR("  %s", msg.doubles[i].name.c_str());
         ROS_ERROR("Strings:");
-        for (unsigned int i = 0; i < msg.strs.size(); i++)
+        for (size_t i = 0; i < msg.strs.size(); i++)
           ROS_ERROR("  %s", msg.strs[i].name.c_str());
         // @todo Check that there are no duplicates. Make this error more
         // explicit.


### PR DESCRIPTION
My team utilizes dynamic_reconfigure and we have a security vulnerability from the code that is auto generated from dynamic_reconfigure.parameter_generator_catkin that utilizes the ConfigType.h template. It involves an issue with consistency of comparison between msg.bools.size() and an unsigned int. To fix this, I made the unsigned int i variable in 4 lines a wider type of size_t to enable consistency in the for loop. 