### PR TITLE
Remove roslib.load_manifest

### DIFF
--- a/scripts/dynparam
+++ b/scripts/dynparam
@@ -36,7 +36,6 @@
 from __future__ import print_function
 
 NAME='dynparam'
-import roslib; roslib.load_manifest('dynamic_reconfigure')
 import rospy
 import optparse
 import sys

--- a/src/dynamic_reconfigure/__init__.py
+++ b/src/dynamic_reconfigure/__init__.py
@@ -35,9 +35,6 @@ Python client API for dynamic_reconfigure (L{Client}) as well as
 example server implementation (L{Server}).
 """
 
-import roslib
-
-
 class DynamicReconfigureException(Exception):
     """
     dynamic_reconfigure base exception type

--- a/src/dynamic_reconfigure/client.py
+++ b/src/dynamic_reconfigure/client.py
@@ -37,10 +37,6 @@ example server implementation (L{DynamicReconfigureServer}).
 
 from __future__ import print_function, with_statement
 
-try:
-    import roslib; roslib.load_manifest('dynamic_reconfigure')
-except Exception:
-    pass
 import rospy
 import sys
 import threading

--- a/src/dynamic_reconfigure/encoding.py
+++ b/src/dynamic_reconfigure/encoding.py
@@ -30,10 +30,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-try:
-    import roslib; roslib.load_manifest('dynamic_reconfigure')
-except Exception:
-    pass
 import copy
 import sys
 

--- a/src/dynamic_reconfigure/parameter_generator.py
+++ b/src/dynamic_reconfigure/parameter_generator.py
@@ -41,7 +41,6 @@
 # Need to put sane error on exceptions
 from __future__ import print_function
 
-import roslib; roslib.load_manifest("dynamic_reconfigure")
 import roslib.packages
 from string import Template
 import os

--- a/src/dynamic_reconfigure/server.py
+++ b/src/dynamic_reconfigure/server.py
@@ -37,10 +37,6 @@ example server implementation (L{DynamicReconfigureServer}).
 
 from __future__ import with_statement
 
-try:
-    import roslib; roslib.load_manifest('dynamic_reconfigure')
-except Exception:
-    pass
 import rospy
 import threading
 import copy

--- a/test/testclient.py
+++ b/test/testclient.py
@@ -32,7 +32,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 from __future__ import print_function
 
-import roslib; roslib.load_manifest('dynamic_reconfigure')
 import rospy
 from dynamic_reconfigure.client import Client as DynamicReconfigureClient
 import time

--- a/test/testserver.py
+++ b/test/testserver.py
@@ -34,7 +34,6 @@
 #********************************************************************/
 from __future__ import print_function
 
-import roslib; roslib.load_manifest('dynamic_reconfigure')
 import rospy
 import dynamic_reconfigure.server
 from dynamic_reconfigure.cfg import TestConfig

--- a/test/testserver_multiple_ns.py
+++ b/test/testserver_multiple_ns.py
@@ -34,7 +34,6 @@
 #********************************************************************/
 from __future__ import print_function
 
-import roslib; roslib.load_manifest('dynamic_reconfigure')
 import rospy
 import dynamic_reconfigure.server
 from dynamic_reconfigure.cfg import TestConfig


### PR DESCRIPTION
Loading this module is slow, especially on a slow disk I/O machine.
After profiling, I found the `roslib.load_manifest` crawls the workspace which slows down the importing.
In this PR, the function calls are removed, as the function is not required nowadays on the latest ROS distribution.